### PR TITLE
Quote all URLs

### DIFF
--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -394,7 +394,7 @@ def request(method, url, **kwargs):
     debug_url = build_url(url, debug_kwargs.pop("params", None))
     logger.debug(
         "Queued %s %s, kwargs: %r", method, debug_url, debug_kwargs)
-    deferred = treq.request(method, url, **kwargs)
+    deferred = treq.request(method, quote(url, safe=":/"), **kwargs)
     deferred.addCallback(unpack_response)
     deferred.addErrback(errback)
 


### PR DESCRIPTION
This fixes a problem where requests would fail if the path contains a
space.

This is still not a proper solution. A real solution would be to use
urlsplit, apply quote only to the path component, then reassemble the
URL. Urlsplit does not appear to be available in Python 2, though.
