### PR TITLE
Return the correct path when caching elsewhere.

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -364,7 +364,7 @@ class JobType(object):
                     stream.write(jobtype["code"])
 
                 jobtype.pop("code", None)
-                return filename, jobtype
+                return tmpfilepath, jobtype
 
         def written_to_disk(results):
             filename, jobtype = results


### PR DESCRIPTION
When the cache couldn't write the jobtype class to its intended
destination and writes to a tempfile instead, it should return the path
it actually wrote the class to instead of the originilly intended one.
