### PR TITLE
Announce current assignments on startup of agent

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -220,7 +220,9 @@ class Agent(object):
             "port": config["port"],
             "free_ram": int(memory.ram_free()),
             "time_offset": config["time-offset"] or 0,
-            "state": config["state"]}
+            "state": config["state"],
+            "current_assignments": config.get(
+                "current_assignments", {})}  # may not be set yet
 
         if "remote-ip" in config:
             data.update(remote_ip=config["remote-ip"])


### PR DESCRIPTION
Previously, the agent would only announce those during its regular
reannounces.
