### PR TITLE
Collect deferreds for processes manually

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -336,9 +336,14 @@ class Process(object):
 
         self._before_start()
         logger.debug("%r.start()", self.__class__.__name__)
-        started = DeferredList(self.start())
+        self.start()
         self.start_called = True
-        self.started_deferred = started
+        logger.debug("Collecting started deferreds from spawned processes")
+        started_deferreds = []
+        for process in self.processes.values():
+            started_deferreds.append(process.started)
+        logger.debug("Making deferred list self.started_deferred")
+        self.started_deferred = DeferredList(started_deferreds)
         self.stopped_deferred = Deferred()
         return self.started_deferred, self.stopped_deferred
 


### PR DESCRIPTION
JobType.start() no longer returns anything, which breaks _start(). This
commit fixes it again by not using deferreds return from start(), but
instead manually collection the deferreds from self.processes.
