### PR TITLE
Allow jobtypes to suppress output lines entirely

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -1101,6 +1101,8 @@ class JobType(Cache, Process, TypeChecks):
         preprocessed = self.preprocess_stdout_line(protocol, stdout)
         if preprocessed is not None:
             stdout = preprocessed
+        if preprocessed == False:
+            return
 
         # Format
         formatted = self.format_stdout_line(protocol, stdout)
@@ -1149,6 +1151,8 @@ class JobType(Cache, Process, TypeChecks):
         preprocessed = self.preprocess_stderr_line(protocol, stderr)
         if preprocessed is not None:
             stderr = preprocessed
+        if preprocessed == False:
+            return
 
         # Format
         formatted = self.format_stderr_line(protocol, stderr)


### PR DESCRIPTION
Previously, preprocess_stdout_line() and preprocess_stderr_line could
only change a given line, but not have it dropped from processing and
logging entirely.  With this change, they can now return False instead
of None to signal that the current line should just be dropped.
