### PR TITLE
removing dangling output preprocessor calls

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -515,21 +515,14 @@ class Process(object):
         """
         if stream == STDOUT:
             line_fragments = self._stdout_line_fragments
-            preprocessor = self.preprocess_stdout
             line_handler = self.handle_stdout_line
 
         elif stream == STDERR:
             line_fragments = self._stderr_line_fragments
-            preprocessor = self.preprocess_stderr
             line_handler = self.handle_stderr_line
 
         else:
             raise ValueError("Expected STDOUT or STDERR for `stream`")
-
-        # Proprocess before we call process_output
-        new_output = preprocessor(protocol, output)
-        if isinstance(new_output, STRING_TYPES):
-            output = new_output
 
         self.process_output(protocol, output, line_fragments, line_handler)
 


### PR DESCRIPTION
Removing calls to preprocess_[stdout|stderr].  This will unbreak the change made in e2f0a3ca140c7dc2b248ab78fe97806.  Rather than reimplementing these calls we should probably remove them for now until we have an explicit need for them since they can always be added back in later on.
