### PR TITLE
Close PID file before deleting it

### DIFF
--- a/pyfarm/agent/entrypoints/main.py
+++ b/pyfarm/agent/entrypoints/main.py
@@ -478,6 +478,7 @@ class AgentEntryPoint(object):
                                 "Process ID in %s is stale.",
                                 config["agent_lock_file"])
                             try:
+                                pidfile.close()
                                 os.remove(config["agent_lock_file"])
                             except OSError as e:
                                 logger.error(


### PR DESCRIPTION
Addresses #135

The agent was first opening the pidfile to check the pid and then, if it
found it to be stale trying to delete it while it was still open.  This
works fine under Linux/Unix, but fails under Windows.
