### PR TITLE
Fix startup when there is no pid file.

### DIFF
--- a/pyfarm/agent/entrypoints/main.py
+++ b/pyfarm/agent/entrypoints/main.py
@@ -477,7 +477,7 @@ class AgentEntryPoint(object):
 
             # If the file is missing we ignore the error and read
             # pid/remove_lock_file later on.
-            except OSError as e:
+            except (OSError, IOError) as e:
                 if e.errno == ENOENT:
                     logger.debug(
                         "Process ID file %s does not exist",


### PR DESCRIPTION
On Windows at least, when the pid file is missing, open() will raise
IOError, not OSError, which the code wouldn't catch.  As a result, the
agent could not start up when no stale pid file was accidentally left
over.
