### PR TITLE
Fix cleaning up assignments with no processes

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -395,7 +395,7 @@ class Process(object):
         if self.processes:
             self.stopped_deferred = Deferred()
         else:
-            # Similar thing as for started, make sure teh assignment is cleaned
+            # Similar thing as for started, make sure the assignment is cleaned
             # up if no processes have been started
             self.stopped_deferred = succeed([])
         return self.started_deferred, self.stopped_deferred


### PR DESCRIPTION
Assignments that start zero processes would linger around forever in the
agent, eventually slowing stuff down by accumulating over time.  This
fixes that.

Some of our jobtypes will check if the desired output files already
exist, and forego starting any processes if they do.
