### PR TITLE
Look for uuid.dat only in explicitly given path

### DIFF
--- a/pyfarm/agent/etc/agent.yml
+++ b/pyfarm/agent/etc/agent.yml
@@ -173,3 +173,10 @@ sysinfo_command_lspci:
   - /sbin/lspci
   - /usr/sbin/lspci
   - /usr/bin/lspci
+
+# The full path where we save our UUID, with different possible settings for
+# different OS types
+uuid_path_linux: /etc/pyfarm/agent/uuid.dat
+uuid_path_bsd: /etc/pyfarm/agent/uuid.dat
+uuid_path_windows: '%LOCALAPPDATA%\pyfarm\agent\uuid.dat'
+uuid_path_mac: /Library/pyfarm/agent/uuid.dat

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -256,29 +256,3 @@ class TestAgentUUID(TestCase):
         self.assertEqual(path, save_path)
         with open(path, "r") as saved_file:
             self.assertEqual(saved_file.read(), str(data))
-
-    def test_save_defaults(self):
-        directories = [
-            tempfile.mkdtemp(),
-            tempfile.mkdtemp(),
-            tempfile.mkdtemp()
-        ]
-        uuids = []
-        for path in directories:
-            self.addCleanup(self._rmdir, path)
-            uuids.append(uuid4())
-
-        def dirs(**kwargs):
-            self.assertIs(kwargs.pop("validate", None), False)
-            self.assertIs(kwargs.pop("unversioned_only", None), True)
-            self.assertNot(kwargs)
-            return directories
-
-        with patch.object(config, "directories", dirs):
-            while directories:
-                data = uuids.pop(0)
-                path = AgentUUID.save(data)
-                save_path = join(directories.pop(0), "uuid.dat")
-                self.assertEqual(path, save_path)
-                with open(save_path, "r") as saved_file:
-                    self.assertEqual(saved_file.read(), str(data))

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -240,30 +240,14 @@ class TestAgentUUID(TestCase):
         self.assertEqual(AgentUUID.load(path), data)
 
     def test_load_from_defaults(self):
-        directories = [
-            tempfile.mkdtemp(),
-            tempfile.mkdtemp(),
-            tempfile.mkdtemp()
-        ]
-        uuids = []
-        for path in directories:
-            self.addCleanup(self._rmdir, path)
-            filepath = join(path, "uuid.dat")
-            data = uuid4()
-            AgentUUID._save(data, filepath)
-            uuids.append(data)
+        directory = tempfile.mkdtemp()
+        uuid = uuid4()
+        self.addCleanup(self._rmdir, path)
+        filepath = join(path, "uuid.dat")
+        AgentUUID.save(uuid, filepath)
 
-        def dirs(**kwargs):
-            self.assertIs(kwargs.pop("validate", None), False)
-            self.assertNot(kwargs)
-            return directories
-
-        with patch.object(config, "directories", dirs):
-            while directories:
-                data = AgentUUID.load()
-                self.assertEqual(uuids[0], data)
-                directories.pop(0)
-                uuids.pop(0)
+        loaded = AgentUUID.load(filepath)
+        self.assertEqual(uuid, loaded)
 
     def test_save_path(self):
         data = uuid4()

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -242,8 +242,8 @@ class TestAgentUUID(TestCase):
     def test_load_from_defaults(self):
         directory = tempfile.mkdtemp()
         uuid = uuid4()
-        self.addCleanup(self._rmdir, path)
-        filepath = join(path, "uuid.dat")
+        self.addCleanup(self._rmdir, directory)
+        filepath = join(directory, "uuid.dat")
         AgentUUID.save(uuid, filepath)
 
         loaded = AgentUUID.load(filepath)


### PR DESCRIPTION
This path can be specified on the command line or in the config file,
but it has to be specified.  We no longer just try the various config
directories.