### PR TITLE
Replace httpbin in tests

### DIFF
--- a/pyfarm/agent/etc/agent.yml
+++ b/pyfarm/agent/etc/agent.yml
@@ -165,8 +165,8 @@ agent_manhole_password: admin
 agent_unittest:
   dns_test_hostname: example.com
   client_redirect_target: http://example.com
-  client_api_test_url_https: https://dev.pyfarm.net/httpbin
-  client_api_test_url_http: http://dev.pyfarm.net/httpbin
+  client_api_test_url_https: https://httpbin.pyfarm.net/
+  client_api_test_url_http: http://httpbin.pyfarm.net/
 
 # A list of paths or names where the `lspci` command can
 # be called from on Linux.  This is used to retrieve information

--- a/pyfarm/agent/etc/agent.yml
+++ b/pyfarm/agent/etc/agent.yml
@@ -165,8 +165,8 @@ agent_manhole_password: admin
 agent_unittest:
   dns_test_hostname: example.com
   client_redirect_target: http://example.com
-  client_api_test_url_https: https://httpbin.org
-  client_api_test_url_http: http://httpbin.org
+  client_api_test_url_https: https://dev.pyfarm.net/httpbin
+  client_api_test_url_http: http://dev.pyfarm.net/httpbin
 
 # A list of paths or names where the `lspci` command can
 # be called from on Linux.  This is used to retrieve information

--- a/pyfarm/agent/etc/agent.yml
+++ b/pyfarm/agent/etc/agent.yml
@@ -165,8 +165,8 @@ agent_manhole_password: admin
 agent_unittest:
   dns_test_hostname: example.com
   client_redirect_target: http://example.com
-  client_api_test_url_https: https://httpbin.pyfarm.net/
-  client_api_test_url_http: http://httpbin.pyfarm.net/
+  client_api_test_url_https: https://httpbin.pyfarm.net
+  client_api_test_url_http: http://httpbin.pyfarm.net
 
 # A list of paths or names where the `lspci` command can
 # be called from on Linux.  This is used to retrieve information

--- a/tests/test_agent/test_http_core_client.py
+++ b/tests/test_agent/test_http_core_client.py
@@ -162,7 +162,7 @@ class RequestTestCase(BaseRequestTestCase):
 
 class TestClientErrors(RequestTestCase):
     def test_unsupported_scheme(self):
-        return get("zzz://dev.pyfarm.net/",
+        return get("zzz://httpbin.pyfarm.net/",
                    callback=lambda _: self.fail("Unexpected success"),
                    errback=lambda failure:
                    self.assertIs(failure.type, SchemeNotSupported))

--- a/tests/test_agent/test_http_core_client.py
+++ b/tests/test_agent/test_http_core_client.py
@@ -162,7 +162,7 @@ class RequestTestCase(BaseRequestTestCase):
 
 class TestClientErrors(RequestTestCase):
     def test_unsupported_scheme(self):
-        return get("zzz://httpbin.org/",
+        return get("zzz://dev.pyfarm.net/",
                    callback=lambda _: self.fail("Unexpected success"),
                    errback=lambda failure:
                    self.assertIs(failure.type, SchemeNotSupported))


### PR DESCRIPTION
Many of our recent test failure are because `http[s]://httpbin.org` has been down or slow to respond, especially over SSL.  This change changes the url we're testing against to point at one of pyfarm's web servers instead.