### PR TITLE
Accept args in lambda for jobtype download errback

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -117,7 +117,8 @@ class Cache(object):
         download = lambda *_: \
             get(url,
                 callback=result.callback,
-                errback=lambda: reactor.callLater(http_retry_delay(), download))
+                errback=lambda *_: reactor.callLater(http_retry_delay(),
+                                                     download))
         download()
         return result
 


### PR DESCRIPTION
This fixes a bug which would leave the agent in an usable state if it
could not reach the master when trying to download a jobtype file.