### PR TITLE
Documentation Update

### DIFF
--- a/docs/source/includes/commands/pyfarm-agent.out
+++ b/docs/source/includes/commands/pyfarm-agent.out
@@ -25,12 +25,15 @@ Agent Network Service:
   --agent-api-password AGENT_API_PASSWORD
                         The password required to access manipulate the agent
                         using REST. [default: agent]
-  --systemid SYSTEMID   The system identification value. This is used to help
-                        identify the system itself to the master when the
-                        agent connects. [default: auto]
-  --systemid-cache SYSTEMID_CACHE
-                        The location to cache the value for --systemid.
-                        [default: None]
+  --agent-id AGENT_ID   The UUID used to identify this agent to the master. By
+                        default the agent will attempt to load a cached value
+                        however a specific UUID could be provided with this
+                        flag.
+  --agent-id-file AGENT_ID_FILE
+                        The location to store the agent's id. By default the
+                        path is platform specific and defined by the
+                        `agent_id_file_platform_defaults` key in the
+                        configuration. [default: /etc/pyfarm/agent/uuid.dat]
 
 Network Resources:
   Resources which the agent will be communicating with.

--- a/docs/source/includes/commands/pyfarm-agent_start.out
+++ b/docs/source/includes/commands/pyfarm-agent_start.out
@@ -7,6 +7,7 @@ usage: pyfarm-agent [status|start|stop] start [-h]
                                               [--no-pretty-json]
                                               [--shutdown-timeout SHUTDOWN_TIMEOUT]
                                               [--updates-drop-dir UPDATES_DROP_DIR]
+                                              [--run-control-file RUN_CONTROL_FILE]
                                               [--cpus CPUS] [--ram RAM]
                                               [--ram-check-interval RAM_CHECK_INTERVAL]
                                               [--ram-max-report-frequency RAM_MAX_REPORT_FREQUENCY]
@@ -64,6 +65,11 @@ General Configuration:
                         The directory to drop downloaded updates in. This
                         should be the same directory pyfarm-supervisor will
                         look for updates in. [default: None]
+  --run-control-file RUN_CONTROL_FILE
+                        The path to a file that will signal to the supervisor
+                        that agent is supposed to be restarted if it stops for
+                        whatever reason.[default:
+                        /tmp/pyfarm/agent/should_be_running]
 
 Physical Hardware:
   Command line flags which describe the hardware of the agent.


### PR DESCRIPTION
Reran the documentation generator against the latest master.  No major changes here except the removal of --systemid* from the docs and the addition of --run-control-file.