### PR TITLE
Improved HTTP Client Setup and Validation

### DIFF
--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -331,17 +331,8 @@ def request(method, url, **kwargs):
     """
     assert isinstance(url, STRING_TYPES)
 
-    # Make sure it's a method we support.
-    if method not in HTTP_METHODS:
-        raise NotImplementedError(
-            "This function only supports these http "
-            "methods: %s" % ", ".join(HTTP_METHODS))
-
     # We only support http[s]
     parsed_url = urlparse(url)
-    if parsed_url.scheme not in HTTP_SCHEMES:
-      raise NotImplementedError("Only http or https is supported.")
-
     if not parsed_url.hostname:
         raise NotImplementedError("No hostname present in url")
 

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -381,7 +381,19 @@ def request(method, url, **kwargs):
             raise NotImplementedError(
                 "cannot handle header values with type %s" % type(value))
 
+    # Handle request data
     data = kwargs.pop("data", NOTSET)
+    if isinstance(data, dict):
+        data = json_safe(data)
+
+    if (data is not NOTSET and
+            headers["Content-Type"] == ["application/json"]):
+        data = json.dumps(data)
+
+    elif data is not NOTSET:
+        raise NotImplementedError(
+            "Don't know how to dump data for %s" % headers["Content-Type"])
+
     callback = kwargs.pop("callback", None)
     errback = kwargs.pop("errback", log.err)
     response_class = kwargs.pop("response_class", Response)
@@ -404,18 +416,6 @@ def request(method, url, **kwargs):
             response_class(deferred, response, original_request))
 
         return deferred
-
-    # prepare to send the data
-    if isinstance(data, dict):
-        data = json_safe(data)
-
-    if data is not NOTSET and \
-                    headers["Content-Type"] == ["application/json"]:
-        data = json.dumps(data)
-
-    elif data is not NOTSET:
-        raise NotImplementedError(
-            "Don't know how to dump data for %s" % headers["Content-Type"])
 
     # prepare keyword arguments
     kwargs.update(

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -394,6 +394,14 @@ def request(method, url, **kwargs):
         raise NotImplementedError(
             "Don't know how to dump data for %s" % headers["Content-Type"])
 
+    # prepare keyword arguments
+    kwargs.update(
+        headers=headers,
+        persistent=config["agent_http_persistent_connections"])
+
+    if data is not NOTSET:
+        kwargs.update(data=data)
+
     callback = kwargs.pop("callback", None)
     errback = kwargs.pop("errback", log.err)
     response_class = kwargs.pop("response_class", Response)
@@ -416,14 +424,6 @@ def request(method, url, **kwargs):
             response_class(deferred, response, original_request))
 
         return deferred
-
-    # prepare keyword arguments
-    kwargs.update(
-        headers=headers,
-        persistent=config["agent_http_persistent_connections"])
-
-    if data is not NOTSET:
-        kwargs.update(data=data)
 
     debug_kwargs = kwargs.copy()
     debug_url = build_url(url, debug_kwargs.pop("params", None))

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -331,9 +331,11 @@ def request(method, url, **kwargs):
     """
     assert isinstance(url, STRING_TYPES)
 
+    # Make sure it's a method we support.
     if method not in HTTP_METHODS:
         raise NotImplementedError(
-            "This function only support these http methods: %s" % HTTP_METHODS)
+            "This function only supports these http "
+            "methods: %s" % ", ".join(HTTP_METHODS))
 
     # We only support http[s]
     parsed_url = urlparse(url)

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -26,6 +26,7 @@ import json
 from collections import namedtuple
 from functools import partial
 from random import random
+from urlparse import urlparse
 
 try:
     from httplib import responses
@@ -66,6 +67,8 @@ else:  # pragma: no cover
 
 USERAGENT = "PyFarm/1.0 (agent)"
 DELAY_NUMBER_TYPES = tuple(list(INTEGER_TYPES) + [float])
+HTTP_METHODS = frozenset(("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"))
+HTTP_SCHEMES = frozenset(("http", "https"))
 
 
 def build_url(url, params=None):
@@ -304,10 +307,22 @@ def request(method, url, **kwargs):
         The class to use to unpack the internal response.  This is mainly
         used by the unittests but could be used elsewhere to add some
         custom behavior to the unpack process for the incoming response.
+
+    :raises NotImplementedError:
+        Raised whenever a request is made of this function that we can't
+        implement such as an invalid http scheme, request method or a problem
+        constructing data to an api.
     """
-    # check assumptions for arguments
-    assert method in ("HEAD", "GET", "POST", "PUT", "PATCH", "DELETE")
-    assert isinstance(url, STRING_TYPES) and url
+    assert isinstance(url, STRING_TYPES)
+
+    if method not in HTTP_METHODS:
+        raise NotImplementedError(
+            "This function only support these http methods: %s" % HTTP_METHODS)
+
+    # We only support http[s]
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in HTTP_SCHEMES:
+      raise NotImplementedError("Only http or https is supported.")
 
     original_request = Request(
         method=method, url=url, kwargs=ImmutableDict(kwargs.copy()))

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -38,6 +38,22 @@ try:
 except ImportError:  # pragma: no cover
     from collections import UserDict
 
+try:
+    import ssl
+except ImportError:  # pragma: no cover
+    ssl = NotImplemented
+
+try:
+    import PyOpenSSL
+except ImportError:  # pragma: no cover
+    PyOpenSSL = NotImplemented
+
+
+try:
+    import service_identity
+except ImportError:  # pragma: no cover
+    service_identity = NotImplemented
+
 import treq
 try:
     from treq.response import _Response as TQResponse
@@ -323,6 +339,17 @@ def request(method, url, **kwargs):
     parsed_url = urlparse(url)
     if parsed_url.scheme not in HTTP_SCHEMES:
       raise NotImplementedError("Only http or https is supported.")
+
+    # When using HTTPs there are some specific modules that are
+    # required but not specified as required in the setup.py file.
+    if parsed_url.scheme == "https":
+        if PyOpenSSL is NotImplemented and ssl is NotImplemented:
+            raise NotImplementedError(
+                "HTTPs requires the ssl or PyOpenSSL modules")
+
+        if service_identity is NotImplemented:
+            raise NotImplementedError(
+                "The service_identity module is required")
 
     original_request = Request(
         method=method, url=url, kwargs=ImmutableDict(kwargs.copy()))

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -392,20 +392,6 @@ def request(method, url, **kwargs):
     assert data is NOTSET or \
            isinstance(data, tuple(list(STRING_TYPES) + [dict, list]))
 
-    # ensure all values in the headers are lists (needed by Twisted)
-    for header, value in headers.items():
-        if isinstance(value, STRING_TYPES):
-            headers[header] = [value]
-
-        # for our purposes we should not expect headers with more
-        # than one value for now
-        elif isinstance(value, (list, tuple, set)):
-            assert len(value) == 1
-
-        else:
-            raise NotImplementedError(
-                "cannot handle header values with type %s" % type(value))
-
     def unpack_response(response):
         deferred = Deferred()
         deferred.addCallback(callback)

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -351,6 +351,12 @@ def request(method, url, **kwargs):
             raise NotImplementedError(
                 "The service_identity module is required")
 
+    if not parsed_url.hostname:
+        raise NotImplementedError("No hostname present in url")
+
+    if not parsed_url.path:
+        raise NotImplementedError("No path provided in url")
+
     original_request = Request(
         method=method, url=url, kwargs=ImmutableDict(kwargs.copy()))
     data = kwargs.pop("data", NOTSET)

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -342,17 +342,6 @@ def request(method, url, **kwargs):
     if parsed_url.scheme not in HTTP_SCHEMES:
       raise NotImplementedError("Only http or https is supported.")
 
-    # When using HTTPs there are some specific modules that are
-    # required but not specified as required in the setup.py file.
-    if parsed_url.scheme == "https":
-        if PyOpenSSL is NotImplemented and ssl is NotImplemented:
-            raise NotImplementedError(
-                "HTTPs requires the ssl or PyOpenSSL modules")
-
-        if service_identity is NotImplemented:
-            raise NotImplementedError(
-                "The service_identity module is required")
-
     if not parsed_url.hostname:
         raise NotImplementedError("No hostname present in url")
 
@@ -430,15 +419,7 @@ def request(method, url, **kwargs):
     logger.debug(
         "Queued %s %s, kwargs: %r", method, debug_url, debug_kwargs)
 
-    try:
-        deferred = treq.request(method, quote_url(url), **kwargs)
-    except NotImplementedError:  # pragma: no cover
-        logger.error(
-            "Attempting to access a url over SSL but you don't have the "
-            "proper libraries installed.  Please install the PyOpenSSL and "
-            "service_identity Python packages.")
-        raise
-
+    deferred = treq.request(method, quote_url(url), **kwargs)
     deferred.addCallback(unpack_response)
     deferred.addErrback(errback)
 

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -361,14 +361,12 @@ def request(method, url, **kwargs):
         if isinstance(value, STRING_TYPES):
             headers[header] = [value]
 
-        # For our purposes we should not expect headers with more
-        # than one value for now
         elif isinstance(value, (list, tuple, set)):
-            assert len(value) == 1
+            continue
 
         else:
             raise NotImplementedError(
-                "cannot handle header values with type %s" % type(value))
+                "Cannot handle header values with type %s" % type(value))
 
     # Handle request data
     data = kwargs.pop("data", NOTSET)

--- a/tests/test_agent/test_http_core_client.py
+++ b/tests/test_agent/test_http_core_client.py
@@ -94,11 +94,6 @@ class TestRequestAssertions(TestCase):
         with self.assertRaises(AssertionError):
             request("GET", "http://localhost/", errback="")
 
-    def test_invalid_header_value_length(self):
-        with self.assertRaises(AssertionError):
-            request("GET", "http://localhost/", callback=lambda: None,
-                    headers={"foo": ["a", "b"]})
-
     def test_invalid_header_value_type(self):
         with self.assertRaises(NotImplementedError):
             request("GET", "/",


### PR DESCRIPTION
This change improves on some validation of the incoming request and also does a bit of reorganization of `request()`.  This change is in preparation for another change which will implement the new http client functionality needed for inlineCallbacks.