### PR TITLE
Silence Configuration Logging during setUp()

### DIFF
--- a/pyfarm/agent/logger/python.py
+++ b/pyfarm/agent/logger/python.py
@@ -40,30 +40,37 @@ class Logger(object):
     """
     def __init__(self, name):
         self.name = name
+        self.disabled = False
 
     def debug(self, message, *args):
-        msg(message, args=args, system=self.name,
-            time=time(), logLevel=DEBUG)
+        if not self.disabled:
+            msg(message, args=args, system=self.name,
+                time=time(), logLevel=DEBUG)
 
     def info(self, message, *args):
-        msg(message, args=args, system=self.name,
-            time=time(), logLevel=INFO)
+        if not self.disabled:
+            msg(message, args=args, system=self.name,
+                time=time(), logLevel=INFO)
 
     def warning(self, message, *args):
-        msg(message, args=args, system=self.name,
-            time=time(), logLevel=WARNING)
+        if not self.disabled:
+            msg(message, args=args, system=self.name,
+                time=time(), logLevel=WARNING)
 
     def error(self, message, *args):
-        msg(message, args=args, system=self.name,
-            time=time(), logLevel=ERROR)
+        if not self.disabled:
+            msg(message, args=args, system=self.name,
+                time=time(), logLevel=ERROR)
 
     def critical(self, message, *args):
-        msg(message, args=args, system=self.name,
-            time=time(), logLevel=CRITICAL)
+        if not self.disabled:
+            msg(message, args=args, system=self.name,
+                time=time(), logLevel=CRITICAL)
 
     def fatal(self, message, *args):
-        msg(message, args=args, system=self.name,
-            time=time(), logLevel=FATAL)
+        if not self.disabled:
+            msg(message, args=args, system=self.name,
+                time=time(), logLevel=FATAL)
 
 
 class LogRecordToTwisted(Handler):

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -373,9 +373,11 @@ class TestCase(_TestCase):
         DelayedCall.debug = True
         if not ENABLE_LOGGING:
             logging.getLogger("pf").setLevel(logging.CRITICAL)
-        config_logger.disabled = 1
+
+        config_logger_disabled = config_logger.disabled
+        config_logger.disabled = True
         self.prepare_config()
-        config_logger.disabled = 0
+        config_logger.disabled = config_logger_disabled
 
     def prepare_config(self):
         for key in self._pop_config_keys:


### PR DESCRIPTION
Currently the config logger is very noisy during the tests making it difficult to quickly find issues.  This change fixes that issue by implementing `.disabled` on our logger class (which we were using but it didn't in fact do anything).

For a comparison, here's [before](https://s3.amazonaws.com/archive.travis-ci.org/jobs/49269512/log.txt) and here's [after](https://s3.amazonaws.com/archive.travis-ci.org/jobs/49270476/log.txt) this change.  Now the only config changes that are logged are those that take place within the test itself.