### PR TITLE
Direct HTTP Client (treq) Request Support

### DIFF
--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -462,6 +462,14 @@ def request(method, url, **kwargs):
         kwargs.update(data=data)
 
     if direct:
+        # We don't support these with direct request
+        # types.
+        assert "callback" not in kwargs
+        assert "errback" not in kwargs
+        assert "response_class" not in kwargs
+
+        # Construct the request and attach some loggers
+        # to callback/errback.
         uid = uuid4()
         treq_request = treq.request(method, url, **kwargs)
         treq_request.addCallback(HTTPLog.response, uid=uid)

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -22,6 +22,7 @@ The client library the manager uses to communicate with
 the master server.
 """
 
+import os
 import json
 from collections import namedtuple
 from functools import partial
@@ -69,6 +70,7 @@ except ImportError:  # pragma: no cover
 from twisted.internet.defer import Deferred
 from twisted.internet.protocol import Protocol, connectionDone
 from twisted.python import log
+from twisted.python.failure import Failure
 from twisted.web.client import (
     Response as TWResponse, GzipDecoder as TWGzipDecoder, ResponseDone)
 

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -519,9 +519,23 @@ def request(method, url, **kwargs):
         return deferred
 
 
+# Old style requests.  These are in place so we can
+# improve on the agent without having to rewrite
+# everything at once.
+# TODO: remove these once everything is converted to *_direct
 head = partial(request, "HEAD")
 get = partial(request, "GET")
 post = partial(request, "POST")
 put = partial(request, "PUT")
 patch = partial(request, "PATCH")
 delete = partial(request, "DELETE")
+
+# New style requests which we can utilize on a case
+# by case basis.
+# TODO: rename these to the above functions once everything is using them
+head_direct = partial(request, "HEAD", direct=True)
+get_direct = partial(request, "GET", direct=True)
+post_direct = partial(request, "POST", direct=True)
+put_direct = partial(request, "PUT", direct=True)
+patch_direct = partial(request, "PATCH", direct=True)
+delete_direct = partial(request, "DELETE", direct=True)

--- a/pyfarm/agent/http/core/client.py
+++ b/pyfarm/agent/http/core/client.py
@@ -396,6 +396,14 @@ def request(method, url, **kwargs):
         raise NotImplementedError(
             "Don't know how to dump data for %s" % headers["Content-Type"])
 
+    # prepare keyword arguments
+    kwargs.update(
+        headers=headers,
+        persistent=config["agent_http_persistent_connections"])
+
+    if data is not NOTSET:
+        kwargs.update(data=data)
+
     if direct:
         pass
     else:
@@ -421,14 +429,6 @@ def request(method, url, **kwargs):
                 response_class(deferred, response, original_request))
 
             return deferred
-
-        # prepare keyword arguments
-        kwargs.update(
-            headers=headers,
-            persistent=config["agent_http_persistent_connections"])
-
-        if data is not NOTSET:
-            kwargs.update(data=data)
 
         debug_kwargs = kwargs.copy()
         debug_url = build_url(url, debug_kwargs.pop("params", None))

--- a/tests/test_agent/test_http_core_client.py
+++ b/tests/test_agent/test_http_core_client.py
@@ -180,18 +180,6 @@ class DirectRequestTestCase(RequestTestCase):
         return delete_direct(self.get_url(url), **kwargs)
 
 
-class TestClientErrors(RequestTestCase):
-    def test_unsupported_scheme(self):
-        with self.assertRaises(NotImplementedError):
-            get("zzz://httpbin.pyfarm.net/")
-
-    def test_unknown_hostname(self):
-        return get(self.HTTP_SCHEME + "://%s/" % os.urandom(8).encode("hex"),
-                   callback=lambda _: self.fail("Unexpected success"),
-                   errback=lambda failure:
-                   self.assertIs(failure.type, DNSLookupError))
-
-
 class TestRetryDelay(TestCase):
     def test_default(self):
         config["http-retry-delay"] = 1


### PR DESCRIPTION
This change adds support to use the treq client as directly as possible and is a continuation of #206 (which should merge first).  This change is also a prerequisite for the inlineCallback work that's being done in other branches but we should be able to merge this without breaking the agent as it stands now.