### PR TITLE
Fix type check in _remove_directories

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -756,7 +756,7 @@ class System(object):
         Removes multiple multiple directories at once, retrying on exit
         for each failure.
         """
-        assert isinstance(directories, (list, tuple))
+        assert isinstance(directories, (list, tuple, set))
         failed = []
 
         for directory in directories:


### PR DESCRIPTION
This should fix the assertion error in #209.  The problem is caused by `self._tempdirs` being a set object originally.