### PR TITLE
Synchronize Agent.shutting_down with the config

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -84,7 +84,6 @@ class Agent(object):
         self.services = {}
         self.register_shutdown_events = False
         self.last_free_ram_post = time.time()
-        self.shutting_down = False
 
         # reannounce_client is set when the agent id is
         # first set. reannounce_client_instance ensures
@@ -117,6 +116,15 @@ class Agent(object):
         agents on the master
         """
         return config["master_api"] + "/agents/"
+
+    @property
+    def shutting_down(self):
+        return config.get("shutting_down", False)
+
+    @shutting_down.setter
+    def shutting_down(self, value):
+        assert value in (True, False)
+        config["shutting_down"] = value
 
     def should_reannounce(self):
         """Small method which acts as a trigger for :meth:`reannounce`"""

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -32,7 +32,7 @@ from pyfarm.agent.sysinfo import network, graphics
 
 
 # TODO: need better tests, these are a little rudimentary at the moment
-class TestAgentBasicMethods(TestCase):
+class TestAgentServiceAttributes(TestCase):
     def test_agent_api_url(self):
         config["agent_id"] = uuid.uuid4()
         agent = Agent()
@@ -76,6 +76,23 @@ class TestAgentBasicMethods(TestCase):
         self.assertApproximates(
             system_data.pop("free_ram"), config["free_ram"], 64)
         self.assertEqual(system_data, expected)
+
+    def test_shutting_down_getter(self):
+        config["shutting_down"] = 42
+        agent = Agent()
+        self.assertEqual(agent.shutting_down, 42)
+
+    def test_shutting_down_settr(self):
+        agent = Agent()
+        agent.shutting_down = True
+        self.assertEqual(config["shutting_down"], True)
+        agent.shutting_down = False
+        self.assertEqual(config["shutting_down"], False)
+
+    def test_shutting_down_settr_invalid_type(self):
+        agent = Agent()
+        with self.assertRaises(AssertionError):
+            agent.shutting_down = None
 
 
 class TestRunAgent(TestCase):


### PR DESCRIPTION
Right now setting `shutting_down` on the agent will not necessarily communicate to other parts of the project, such as job types or other code which does not have easy access to the agent instance, that the agent is shutting down.  This change fixes this by turning `shutting_down` into a property that will return a result from the config when `self.shutting_down` is requested and set the value in the config with `self.shutting_down = <value>` 