### PR TITLE
Convert post_agent_to_master to inlineCallbacks

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -631,7 +631,6 @@ class Agent(object):
                     "responded with was %r.  Sorry, but we cannot retry this "
                     "request as it's an issue with the agent's request.",
                     url, response.code, text)
-                returnValue(None)
 
             else:
                 data = yield treq.json_content(response)

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -591,7 +591,7 @@ class Agent(object):
                 svclog.error(
                     "Failed to POST agent to master, the connection was "
                     "refused. Retrying in %s seconds")
-            else:
+            else:  # pragma: no cover
                 svclog.error(
                     "Unhandled error when trying to POST the agent to the "
                     "master. The error was %s.", failure)

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -79,8 +79,6 @@ class Agent(object):
     itself with the master, starting the periodic task manager,
     and handling shutdown conditions.
     """
-    reactor = reactor
-
     def __init__(self):
         # so parts of this instance are accessible elsewhere
         assert "agent" not in config
@@ -594,8 +592,7 @@ class Agent(object):
                 delay = http_retry_delay()
                 svclog.info(
                     "Retrying failed POST to master in %s seconds.", delay)
-                yield deferLater(
-                    self.reactor, delay, self.post_agent_to_master)
+                yield deferLater(reactor, delay, self.post_agent_to_master)
             else:
                 svclog.warning("Not retrying POST to master, shutting down.")
 
@@ -609,8 +606,7 @@ class Agent(object):
                         "Failed to post to master due to a server side error "
                         "error %s, retrying in %s seconds",
                         response.code, delay)
-                    yield deferLater(
-                        self.reactor, delay, self.post_agent_to_master)
+                    yield deferLater(reactor, delay, self.post_agent_to_master)
                 else:
                     svclog.warning(
                         "Failed to post to master due to a server side error "

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -643,6 +643,8 @@ class Agent(object):
                         "with an id of %s was created.",
                         url, config["agent_id"])
 
+                returnValue(data)
+
     def callback_post_free_ram(self, response):
         """
         Called when we get a response back from the master

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -620,12 +620,14 @@ class Agent(object):
             # Master is up but is rejecting our request because there's
             # something wrong with it.  Do not retry the request.
             elif response.code >= BAD_REQUEST:
+                text = yield response.text()
                 svclog.error(
                     "%s accepted our POST request but responded with code %s "
                     "which is a client side error.  The message the server "
                     "responded with was %r.  Sorry, but we cannot retry this "
                     "request as it's an issue with the agent's request.",
-                    url, response.code, response.data())
+                    url, response.code, text)
+                returnValue(None)
 
             else:
                 data = yield treq.json_content(response)

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -125,6 +125,18 @@ class skipIf(object):
             return func(*args, **kwargs)
         return wrapper
 
+
+def random_port(bind="127.0.0.1"):
+    """Returns a random port which is not in use"""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind((bind, 0))
+        _, port = sock.getsockname()
+        return port
+    finally:
+        sock.close()
+
+
 def requires_master(function):
     """
     Any test decorated with this function will fail if the master could

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -273,6 +273,7 @@ class ErrorCapturingParser(AgentArgumentParser):
 
 
 class TestCase(_TestCase):
+    longMessage = True
     POP_CONFIG_KEYS = []
     RAND_LENGTH = 8
 

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -348,7 +348,7 @@ class TestCase(_TestCase):
                         msg, '%s not less than or equal to %s' % (a, b)))
 
         def assertGreaterEqual(self, a, b, msg=None):
-            if not a <= b:
+            if not a >= b:
                 self.fail(
                     self._formatMessage(
                         msg, '%s not greater than or equal to %s' % (a, b)))

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -330,6 +330,18 @@ class TestCase(_TestCase):
 
     # back ports of some of Python 2.7's unittest features
     if PY26:
+        def assertLessEqual(self, a, b, msg=None):
+            if not a <= b:
+                self.fail(
+                    self._formatMessage(
+                        msg, '%s not less than or equal to %s' % (a, b)))
+
+        def assertGreaterEqual(self, a, b, msg=None):
+            if not a <= b:
+                self.fail(
+                    self._formatMessage(
+                        msg, '%s not greater than or equal to %s' % (a, b)))
+
         def assertIsNone(self, obj, msg=None):
             if obj is not None:
                 self.fail(self._formatMessage(msg, "%r is not None" % obj))

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -330,6 +330,16 @@ class TestCase(_TestCase):
 
     # back ports of some of Python 2.7's unittest features
     if PY26:
+        def _formatMessage(self, msg, standardMsg):
+            if not self.longMessage:
+                return msg or standardMsg
+            if msg is None:
+                return standardMsg
+            try:
+                return '%s : %s' % (standardMsg, msg)
+            except UnicodeDecodeError:
+                return '%s : %s' % (standardMsg, msg)
+
         def assertLessEqual(self, a, b, msg=None):
             if not a <= b:
                 self.fail(

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -408,6 +408,7 @@ class TestCase(_TestCase):
             config.pop(key, None)
 
         config.update({
+            "shutting_down": False,
             "jobtypes": {},
             "current_assignments": {},
             "agent_id": uuid.uuid4(),

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -78,9 +78,3 @@ class TestAgentBasicMethods(TestCase):
         self.assertEqual(system_data, expected)
 
 
-class TestRunAgent(TestCase):
-    def test_created(self):
-        self.skipTest("NOT IMPLEMENTED")
-
-    def test_updated(self):
-        self.skipTest("NOT IMPLEMENTED")

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -18,8 +18,6 @@ import os
 import json
 import uuid
 from datetime import datetime, timedelta
-from functools import partial
-from logging import DEBUG, INFO, WARNING, ERROR, CRITICAL
 from platform import platform
 
 try:
@@ -31,7 +29,7 @@ from mock import patch
 from twisted.internet import reactor
 from twisted.web.resource import Resource
 from twisted.web.server import Site, NOT_DONE_YET
-from twisted.internet.defer import Deferred, inlineCallbacks
+from twisted.internet.defer import inlineCallbacks
 
 from pyfarm.core.enums import AgentState
 from pyfarm.agent.sysinfo.system import operating_system

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -133,6 +133,7 @@ class TestAgentPostToMaster(TestCase):
 
     @inlineCallbacks
     def tearDown(self):
+        super(TestAgentPostToMaster, self).tearDown()
         yield self.server.loseConnection()
 
     @inlineCallbacks


### PR DESCRIPTION
Similar to other recent branches the focus of this change is to convert a part of `service.py` to use inlineCallbacks.  In this case, the part which is performing a POST request to register the agent with the master.