### PR TITLE
Convert post_shutdown_to_master to inlineCallbacks

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -526,7 +526,7 @@ class Agent(object):
 
             # We're hit the timeout
             if datetime.utcnow() > self.shutdown_timeout:
-                svclog.info("Shutdown timeout reached!")
+                svclog.error("Shutdown timeout reached!")
                 break
 
             for jobtype_id, jobtype in config["jobtypes"].copy().items():

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -764,7 +764,6 @@ class Agent(object):
             self.shutdown_timeout = None
             return
 
-        self.shutdown_timeout = \
-            datetime.utcnow() + timedelta(
-                seconds=config["agent_shutdown_timeout"])
+        self.shutdown_timeout = timedelta(
+            seconds=config["agent_shutdown_timeout"]) + datetime.utcnow()
         svclog.debug("New shutdown_timeout is %s", self.shutdown_timeout)

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -635,7 +635,7 @@ class Agent(object):
                         svclog.warning(
                             "State update failed due to server error: %s.  "
                             "Retrying in %s seconds.",
-                            response.data(), delay)
+                            data, delay)
 
                         # Wait for 'pause' to fire, introducing a delay
                         pause = Deferred()

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -618,7 +618,8 @@ class Agent(object):
 
                 elif response.code == OK:
                     svclog.info(
-                        "Agent %r has shutdown successfully.",
+                        "Agent %r has POSTed shutdown state change "
+                        "successfully.",
                         config["agent_id"])
                     break
 

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -513,7 +513,7 @@ class Agent(object):
             except Exception as error:  # pragma: no cover
                 svclog.warning(
                     "Error while calling stop() on %s (id: %s): %s",
-                    jobtype, uuid, error
+                    jobtype, jobtype_id, error
                 )
                 config["jobtypes"].pop(jobtype_id)
 

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -590,14 +590,18 @@ class Agent(object):
                         "State update failed due to unhandled error: %s.  "
                         "Retrying in %s seconds",
                         failure, delay)
+
+                    # Wait for 'pause' to fire, introducing a delay
                     pause = Deferred()
                     reactor.callLater(delay, pause.callback, None)
                     yield pause
+
                 else:
                     svclog.warning(
                         "State update failed due to unhandled error: %s.  "
                         "Shutdown timeout reached, not retrying.",
                         failure)
+                    break
 
             else:
                 data = yield treq.json_content(response)
@@ -620,6 +624,8 @@ class Agent(object):
                             "State update failed due to server error: %s.  "
                             "Retrying in %s seconds.",
                             response.data(), delay)
+
+                        # Wait for 'pause' to fire, introducing a delay
                         pause = Deferred()
                         reactor.callLater(delay, pause.callback, None)
                         yield pause

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -507,7 +507,7 @@ class Agent(object):
             config["agent_lock_file"], retry_on_exit=True, raise_=False)
 
         svclog.debug("Stopping execution of jobtypes")
-        for uuid, jobtype in config["jobtypes"].items():
+        for jobtype_id, jobtype in config["jobtypes"].items():
             try:
                 jobtype.stop()
             except Exception as error:  # pragma: no cover
@@ -515,6 +515,7 @@ class Agent(object):
                     "Error while calling stop() on %s (id: %s): %s",
                     jobtype, uuid, error
                 )
+                config["jobtypes"].pop(jobtype_id)
 
         svclog.info(
             "Waiting on %s job types to terminate", len(config["jobtypes"]))

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -520,16 +520,7 @@ class Agent(object):
         svclog.info(
             "Waiting on %s job types to terminate", len(config["jobtypes"]))
 
-        while True:
-            # No jobtypes remain
-            if not config["jobtypes"]:
-                break
-
-            # We're hit the timeout
-            if datetime.utcnow() > self.shutdown_timeout:
-                svclog.error("Shutdown timeout reached!")
-                break
-
+        while config["jobtypes"] and datetime.utcnow() < self.shutdown_timeout:
             for jobtype_id, jobtype in config["jobtypes"].copy().items():
                 if not jobtype._has_running_processes():
                     svclog.warning(

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -507,7 +507,6 @@ class Agent(object):
             config["agent_lock_file"], retry_on_exit=True, raise_=False)
 
         svclog.debug("Stopping execution of jobtypes")
-
         for uuid, jobtype in config["jobtypes"].items():
             try:
                 jobtype.stop()
@@ -532,7 +531,7 @@ class Agent(object):
 
             for jobtype_id, jobtype in config["jobtypes"].copy().items():
                 if not jobtype._has_running_processes():
-                    svclog.error(
+                    svclog.warning(
                         "%r has not removed itself, forcing removal",
                         jobtype)
                     config["jobtypes"].pop(jobtype_id)

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -566,6 +566,11 @@ class Agent(object):
         This method is called before the reactor shuts down and lets the
         master know that the agent's state is now ``offline``
         """
+        # We're under the assumption that something's wrong with
+        # our code if we try to call this method before self.shutting_down
+        # is set.
+        assert self.shutting_down
+
         svclog.info("Informing master of shutdown")
 
         # Because post_shutdown_to_master is blocking and needs to

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -425,6 +425,7 @@ class TestCase(_TestCase):
             "agent_id": uuid.uuid4(),
             "agent_http_retry_delay": 1,
             "agent_http_persistent_connections": False,
+            "agent_shutdown_timeout": 3,
             "master": PYFARM_AGENT_MASTER,
             "agent_hostname": os.urandom(self.RAND_LENGTH).encode("hex"),
             "agent_ram": memory.total_ram(),

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
 from mock import patch
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, DeferredList
-from twisted.internet.error import ConnectionRefusedError
+from twisted.internet.task import deferLater
 from twisted.web.resource import Resource
 from twisted.web.server import Site, NOT_DONE_YET
 from twisted.internet.defer import inlineCallbacks

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -815,17 +815,15 @@ class TestStop(TestCase):
         with nested(
             patch.object(agent.stop_lock, "acquire"),
             patch.object(agent.stop_lock, "release"),
-            patch.object(svclog, "error"),
             patch.object(agent, "agent_api", return_value=None),
         ) as (
-            stop_lock_acquire, stop_lock_release, error_log,
+            stop_lock_acquire, stop_lock_release,
             agent_api
         ):
             result = yield agent.stop()
 
         self.assertIsNone(result)
         agent_api.assert_called_once()
-        error_log.assert_called_with("Shutdown timeout reached!")
         stop_lock_acquire.assert_called_once()
         stop_lock_release.assert_called_once()
 

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -584,11 +584,11 @@ class TestPostShutdownToMaster(TestCase):
         self.assertEqual(release.call_count, 1)
 
 
-class TestStop(TestCase):
+class TestSigintHandler(TestCase):
     POP_CONFIG_KEYS = ["run_control_file"]
 
     def setUp(self):
-        super(TestStop, self).setUp()
+        super(TestSigintHandler, self).setUp()
         config["run_control_file"] = ""
 
     def test_sigint_removes_file(self):
@@ -634,8 +634,11 @@ class TestStop(TestCase):
         self.assertEqual(agent_stop.call_count, 1)
         self.assertEqual(reactor_stop.call_count, 1)
 
+        # Manually test the call args because assert_called_with would
+        # require the exact instance of the Failure object.
         self.assertEqual(
             error_log.call_args[0][0],
             "Error while attempting to shutdown the agent: %s")
         self.assertIsInstance(error_log.call_args[0][1], Failure)
         sys_exit.assert_called_with(1)
+

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -141,6 +141,24 @@ class TestAgentServiceAttributes(TestCase):
         self.assertEqual(
             schedule_call_args[0][0][1], agent.reannounce)
 
+    def test_callback_shutting_down_true(self):
+        config["agent_shutdown_timeout"] = 4242
+        agent = Agent()
+        self.assertIsNone(agent.shutdown_timeout)
+        agent.shutting_down = True
+        self.assertIsInstance(agent.shutdown_timeout, datetime)
+        expected = timedelta(
+            seconds=config["agent_shutdown_timeout"]) + datetime.utcnow()
+        self.assertDateAlmostEqual(agent.shutdown_timeout, expected)
+
+    def test_callback_shutting_down_false(self):
+        config["agent_shutdown_timeout"] = 4242
+        agent = Agent()
+        self.assertIsNone(agent.shutdown_timeout)
+        agent.shutting_down = True
+        agent.shutting_down = False
+        self.assertIsNone(agent.shutdown_timeout)
+
     def test_shutting_down_getter(self):
         config["shutting_down"] = 42
         agent = Agent()

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -429,7 +429,6 @@ class TestPostShutdownToMaster(TestCase):
         self.site = Site(self.resource)
         self.server = reactor.listenTCP(random_port(), self.site)
         config["master_api"] = "http://127.0.0.1:%s" % self.server.port
-        config["shutting_down"] = True
 
         # These usually come from the master.  We're setting them here
         # so we can operate the apis without actually talking to the
@@ -470,6 +469,7 @@ class TestPostShutdownToMaster(TestCase):
             messages.append((message, args, kwargs))
 
         agent = Agent()
+        agent.shutting_down = True
         with patch.object(svclog, "warning", capture_messages):
             result = yield agent.post_shutdown_to_master()
 
@@ -490,6 +490,7 @@ class TestPostShutdownToMaster(TestCase):
             messages.append((message, args, kwargs))
 
         agent = Agent()
+        agent.shutting_down = True
         with patch.object(svclog, "info", capture_messages):
             result = yield agent.post_shutdown_to_master()
 


### PR DESCRIPTION
This change converts post_shutdown_to_master to inlineCallbacks.  In addition this change also fixes a couple of bugs regarding the shutdown timeout.