### PR TITLE
Fix spurious newlines in CSVs in Windows

### DIFF
--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -24,7 +24,6 @@ are copied over from the master (which we can't import here).
 
 import csv
 import codecs
-import cStringIO
 import os
 from decimal import Decimal
 from datetime import datetime, timedelta
@@ -237,24 +236,11 @@ class UnicodeCSVWriter(object):
     A CSV writer which will write rows to CSV file "f",
     which is encoded in the given encoding.
     """
-    def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
-        # Redirect output to a queue
-        self.queue = cStringIO.StringIO()
-        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
-        self.stream = f
-        self.encoder = codecs.getincrementalencoder(encoding)()
+    def __init__(self, f, dialect=csv.excel, **kwds):
+        self.writer = csv.writer(f, dialect=dialect, **kwds)
 
     def writerow(self, row):
         self.writer.writerow([s.encode("utf-8") for s in row])
-        # Fetch UTF-8 output from the queue ...
-        data = self.queue.getvalue()
-        data = data.decode("utf-8")
-        # ... and reencode it into the target encoding
-        data = self.encoder.encode(data)
-        # write to the target stream
-        self.stream.write(data)
-        # empty queue
-        self.queue.truncate(0)
 
     def writerows(self, rows):
         for row in rows:

--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -70,7 +70,7 @@ def open_log(path, ignore_existing=False):
                 raise
 
         logger.debug("Opening log file %r", path)
-        return open(path, "w")
+        return open(path, "wb")
 
 
 class CSVLog(object):

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -122,24 +122,26 @@ class TestCSVBase(TestCase):
 
     def get_writer(self):
         stream = open(self.create_file(), "w")
-        return UnicodeCSVWriter(stream), stream.name
+        return UnicodeCSVWriter(stream), stream
 
 
 class TestCSVWriter(TestCSVBase):
     def test_writerow(self):
-        writer, path = self.get_writer()
+        writer, stream = self.get_writer()
+        path = stream.name
         row = self.get_row()
         writer.writerow(row)
-        writer.stream.close()
+        stream.close()
         with open(path, "r") as stream:
             written_row = stream.read()
         self.assertEqual(written_row.strip(), ",".join(row))
 
     def test_writerows(self):
-        writer, path = self.get_writer()
+        writer, stream = self.get_writer()
+        path = stream.name
         rows = [self.get_row() for _ in range(5)]
         writer.writerows(rows)
-        writer.stream.close()
+        stream.close()
         with open(path, "r") as stream:
             written_rows = stream.read()
 
@@ -149,10 +151,11 @@ class TestCSVWriter(TestCSVBase):
 
 class TestCSVReader(TestCSVBase):
     def test_iter(self):
-        writer, path = self.get_writer()
+        writer, stream = self.get_writer()
+        path = stream.name
         rows = [self.get_row() for _ in range(5)]
         writer.writerows(rows)
-        writer.stream.close()
+        stream.close()
         reader = UnicodeCSVReader(open(path))
 
         written_rows = []
@@ -161,10 +164,11 @@ class TestCSVReader(TestCSVBase):
         self.assertEqual(written_rows, rows)
 
     def test_next(self):
-        writer, path = self.get_writer()
+        writer, stream = self.get_writer()
+        path = stream.name
         rows = [self.get_row() for _ in range(5)]
         writer.writerows(rows)
-        writer.stream.close()
+        stream.close()
         reader = UnicodeCSVReader(open(path))
 
         written_rows = []

--- a/tests/test_jobtypes/test_core_log.py
+++ b/tests/test_jobtypes/test_core_log.py
@@ -67,7 +67,7 @@ class TestModuleLevel(TestCase):
         result = open_log(outfile)
         self.assertTrue(isfile(outfile))
         self.assertIsInstance(result, file)
-        self.assertEqual(result.mode, "w")
+        self.assertEqual(result.mode, "wb")
 
     def test_file_exists(self):
         outdir, _ = self.create_directory(0)


### PR DESCRIPTION
This also removes the indirection via in-memory file objects for writing
CSVs and the encoding feature for the csv output. This feature was never
actually used anywhere, and the resulting behaviour not relied upon.

Keeping the indirection makes it impossible to fix this bug.