### PR TITLE
Remove File Utility

### DIFF
--- a/pyfarm/agent/config.py
+++ b/pyfarm/agent/config.py
@@ -37,7 +37,7 @@ from os.path import join, abspath, dirname
 from pyfarm.core.enums import NOTSET
 from pyfarm.core.config import Configuration
 from pyfarm.agent.logger import getLogger
-from pyfarm.agent.sysinfo import memory, cpu, network, system
+from pyfarm.agent.sysinfo import memory, cpu, network
 
 logger = getLogger("agent.config")
 

--- a/pyfarm/agent/entrypoints/supervisor.py
+++ b/pyfarm/agent/entrypoints/supervisor.py
@@ -21,7 +21,6 @@ import sys
 import time
 import shutil
 import zipfile
-from functools import partial
 from os.path import join, isdir, isfile
 
 # Platform specific imports.  These should either all fail or

--- a/pyfarm/agent/entrypoints/supervisor.py
+++ b/pyfarm/agent/entrypoints/supervisor.py
@@ -43,6 +43,7 @@ from pyfarm.agent.config import config
 from pyfarm.agent.entrypoints.parser import AgentArgumentParser
 from pyfarm.agent.entrypoints.utility import start_daemon_posix
 from pyfarm.agent.logger import getLogger
+from pyfarm.agent.utility import remove_file
 
 logger = getLogger("agent.supervisor")
 
@@ -160,7 +161,9 @@ def supervisor():
                     os.makedirs(args.agent_package_dir)
                     with zipfile.ZipFile(update_file_path, "r") as archive:
                         archive.extractall(args.agent_package_dir)
-                    os.remove(update_file_path)
+
+                    remove_file(
+                        update_file_path, retry_on_exit=True, raise_=False)
                 except Exception as e:
                     logger.error(
                         "Caught exception trying to update agent: %r", e)

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -23,20 +23,13 @@ Sends and receives information from the master and performs systems level tasks
 such as log reading, system information gathering, and management of processes.
 """
 
-import atexit
 import os
 import time
 import uuid
 from datetime import datetime, timedelta
-from errno import ENOENT
 from functools import partial
-from os.path import join, isfile
+from os.path import join
 from platform import platform
-
-try:
-    WindowsError
-except NameError:  # pragma: no cover
-    WindowsError = OSError
 
 try:
     from httplib import (
@@ -67,6 +60,7 @@ from pyfarm.agent.http.core.server import Site, StaticPath
 from pyfarm.agent.http.system import Index, Configuration
 from pyfarm.agent.logger import getLogger
 from pyfarm.agent.sysinfo import memory, network, system, cpu, graphics
+from pyfarm.agent import utility
 
 svclog = getLogger("agent.service")
 ntplog = getLogger("agent.service.ntp")
@@ -495,22 +489,8 @@ class Agent(object):
                 datetime.utcnow() + timedelta(
                     seconds=config["agent_shutdown_timeout"]))
 
-            def remove_pidfile():
-                if not isfile(config["agent_lock_file"]):
-                    svclog.warning(
-                        "%s does not exist", config["agent_lock_file"])
-                    return
-
-                try:
-                    os.remove(config["agent_lock_file"])
-                    svclog.debug(
-                        "Removed pidfile %r", config["agent_lock_file"])
-                except (OSError, IOError) as e:
-                    svclog.error(
-                        "Failed to remove lock file %r: %s",
-                        config["agent_lock_file"], e)
-
-            atexit.register(remove_pidfile)
+            utility.remove_file(
+                config["agent_lock_file"], retry_on_exit=True, raise_=False)
 
             svclog.debug("Stopping execution of jobtypes")
             for uuid, jobtype in config["jobtypes"].items():
@@ -537,27 +517,8 @@ class Agent(object):
             wait_on_stopped()
 
     def sigint_handler(self, *_):
-        try:
-            os.remove(config["run_control_file"])
-        except (WindowsError, OSError, IOError) as e:
-            if e.errno != ENOENT:
-                svclog.error("Could not delete run control file %s: %s: %s",
-                             config["run_control_file"],
-                             type(e).__name__, e)
-
-                def remove_run_control_file():
-                    try:
-                        os.remove(config["run_control_file"])
-                        svclog.debug("Removed run control file %r",
-                                     config["run_control_file"])
-                    except (OSError, IOError, WindowsError) as e:
-                        svclog.error("Failed to remove run control file %s: "
-                                     "%s: %s",
-                                    config["run_control_file"],
-                                    type(e).__name__, e)
-
-                atexit.register(remove_run_control_file)
-
+        utility.remove_file(
+            config["run_control_file"], retry_on_exit=True, raise_=False)
         self.stop()
 
     def post_shutdown_to_master(self, stop_reactor=True):

--- a/pyfarm/agent/sysinfo/system.py
+++ b/pyfarm/agent/sysinfo/system.py
@@ -23,24 +23,18 @@ and other relevant information.  This module may also contain os specific
 information such as the Linux distribution, Windows version, bitness, etc.
 """
 
-import atexit
 import os
 import platform
 import sys
 import time
 import tempfile
 import uuid
-from errno import ENOENT
 from os.path import isfile
 
 import psutil
 
-try:
-    WindowsError
-except NameError:  # pragma: no cover
-    WindowsError = OSError
-
 from pyfarm.agent.logger import getLogger
+from pyfarm.agent.utility import remove_file
 
 logger = getLogger("agent.sysinfo")
 
@@ -57,22 +51,7 @@ except NameError:  # pragma: no cover
     except OSError:  # pragma: no cover
         pass
 
-    try:
-        os.remove(path)
-    except (WindowsError, OSError, NotImplementedError) as e:
-        if getattr(e, "errno", None) != ENOENT:
-            logger.warning("Could not remove temp file %s: %s: %s",
-                           path, type(e).__name__, e)
-
-            # Try to remove the file on shutdown
-            @atexit.register
-            def remove():
-                try:
-                    os.remove(path)
-                except (WindowsError, OSError, NotImplementedError) as e:
-                    if getattr(e, "errno", None) != ENOENT:
-                        logger.error("Failed to remove %s: %s", path, e)
-        del e
+    remove_file(path, retry_on_exit=True, raise_=False)
     del fd, path
 
 # Determine if environment is case sensitive

--- a/pyfarm/agent/sysinfo/system.py
+++ b/pyfarm/agent/sysinfo/system.py
@@ -41,7 +41,6 @@ except NameError:  # pragma: no cover
     WindowsError = OSError
 
 from pyfarm.agent.logger import getLogger
-from pyfarm.agent.sysinfo.network import mac_addresses
 
 logger = getLogger("agent.sysinfo")
 

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -349,20 +349,21 @@ class AgentUUID(object):
 def remove_file(
         path, retry_on_exit=False, raise_=True, ignored_errnos=(ENOENT, )):
     """
-    Simple function to remove the provided file or retry on shutdown
+    Simple function to remove the provided file or retry on exit
     if requested.  This function standardizes the log output, ensures
     it's only called once per path on exit and handles platform
     specific exceptions (ie. ``WindowsError``).
 
     :param bool retry_on_exit:
-        If True, retry removal of the file on shutdown.
+        If True, retry removal of the file when Python exists.
 
     :param bool raise_:
         If True, raise an exceptions produced.  This will always be
         False if :func:`remove_file` is being executed by :module:`atexit`
 
     :param tuple ignored_errnos:
-        A tuple of ignored error numbers.  By default we only ig
+        A tuple of ignored error numbers.  By default this function
+        only ignores ENOENT.
     """
     try:
         os.remove(path)

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -30,9 +30,9 @@ from decimal import Decimal
 from datetime import datetime, timedelta
 from errno import EEXIST, ENOENT, errorcode
 from json import dumps as _dumps
-from os.path import join, dirname
+from os.path import dirname
 from UserDict import UserDict
-from uuid import UUID, uuid1, uuid4
+from uuid import UUID, uuid4
 
 try:
     from urlparse import urlsplit

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -371,13 +371,16 @@ def remove_file(
             return
 
         if retry_on_exit:
-            logger.debug(
-                "Could not remove %s (%s), will retry on shutdown.",
-                path, errorcode[error.errno]
-            )
+            logger.warning(
+                "Failed to remove %s (%s), will retry on exit",
+                path, errorcode[error.errno])
             atexit.register(
                 remove_file, path,
                 retry_on_exit=False, raise_=False)
+        else:
+            logger.error(
+                "Failed to remove %s (%s)",
+                path, errorcode[error.errno])
 
         if raise_:
             raise

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -377,7 +377,7 @@ def remove_file(
             )
             atexit.register(
                 remove_file, path,
-                retry_on_shutdown=False, raise_=False)
+                retry_on_exit=False, raise_=False)
 
         if raise_:
             raise

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -347,12 +347,12 @@ class AgentUUID(object):
 
 
 def remove_file(
-        path, retry_on_shutdown=False, raise_=True, ignored_errnos=(ENOENT, )):
+        path, retry_on_exit=False, raise_=True, ignored_errnos=(ENOENT, )):
     """
     Simple function to remove the provided file or retry
     on shutdown if requested.
 
-    :param bool retry_on_shutdown:
+    :param bool retry_on_exit:
         If True, retry removal of the file on shutdown.
 
     :param bool raise_:
@@ -370,7 +370,7 @@ def remove_file(
                 "Failed to remove %s (%s)", path, errorcode[error.errno])
             return
 
-        if retry_on_shutdown:
+        if retry_on_exit:
             logger.debug(
                 "Could not remove %s (%s), will retry on shutdown.",
                 path, errorcode[error.errno]

--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -64,6 +64,7 @@ from pyfarm.core.enums import WINDOWS, INTEGER_TYPES, STRING_TYPES, WorkState
 from pyfarm.agent.config import config
 from pyfarm.agent.logger import getLogger
 from pyfarm.agent.http.core.client import get, post, http_retry_delay
+from pyfarm.agent.utility import remove_file
 from pyfarm.jobtypes.core.log import STDOUT, STDERR, logpool
 from pyfarm.jobtypes.core.process import ReplaceEnvironment, ProcessProtocol
 
@@ -827,7 +828,8 @@ class System(object):
                 os.stat(element["filepath"]).st_mtime + minimum_age <
                     time.time()):
                 logger.debug("Deleting tempfile %s", element["filepath"])
-                os.remove(element["filepath"])
+                remove_file(
+                    element["filepath"], retry_on_exit=False, raise_=False)
             else:
                 logger.debug("Not deleting tempfile %s, it is newer than %s "
                              "seconds", element["filepath"], minimum_age)

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -35,6 +35,11 @@ from pyfarm.agent.utility import (
     quote_url, request_from_master, total_seconds, validate_environment,
     AgentUUID, remove_file, logger)
 
+try:
+    WindowsError
+except NameError:  # pragma: no cover
+    WindowsError = OSError
+
 
 class TestValidateEnvironment(TestCase):
     def test_type(self):
@@ -281,7 +286,7 @@ class TestRemoveFile(TestCase):
     def test_retry_on_shutdown_raise(self):
         os.remove(self.path)
 
-        with self.assertRaises(OSError):
+        with self.assertRaises((WindowsError, OSError, IOError)):
             remove_file(
                 self.path, ignored_errnos=(), retry_on_exit=True, raise_=True)
 


### PR DESCRIPTION
While looking around to figure out the next best code to transition to inlineCallbacks I found it would be easier to do a little cleanup first.  In this case I'm migrating calls to `os.remove` to a utility function which will file removal in a consistent manner while also offering some extra options.  The goal here is to provide a little cleanup while also not changing the intended behavior of the code being replaced.

This could also be used by job type implementors to handle file removal without having to write a bunch of wrapper code.