### PR TITLE
Convert reannounce to inlineCallbacks

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -221,6 +221,8 @@ class Agent(object):
             return False
 
         contacted = config.master_contacted(update=False)
+        if contacted is None:
+            return True
         remaining = (datetime.utcnow() - contacted).total_seconds()
         return remaining > config["agent_master_reannounce"]
 

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -86,13 +86,8 @@ class Agent(object):
         self.shutdown_timeout = None
         self.post_shutdown_lock = DeferredLock()
         self.stop_lock = DeferredLock()
+        self.reannouce_lock = DeferredLock()
         self.stopped = False
-
-        # reannounce_client is set when the agent id is
-        # first set. reannounce_client_instance ensures
-        # that once we start the announcement process we
-        # won't try another until we're finished
-        self.reannounce_client_request = None
 
         # Register a callback so self.shutdown_timeout is set when
         # "shutting_down" is set or modified.

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -48,7 +48,8 @@ except ImportError:  # pragma: no cover
 import treq
 from ntplib import NTPClient
 from twisted.internet import reactor
-from twisted.internet.defer import Deferred, inlineCallbacks, returnValue
+from twisted.internet.defer import (
+    Deferred, inlineCallbacks, returnValue, DeferredLock)
 from twisted.internet.error import ConnectionRefusedError
 from twisted.internet.task import deferLater
 
@@ -87,12 +88,7 @@ class Agent(object):
         self.register_shutdown_events = False
         self.last_free_ram_post = time.time()
         self.repeating_call_counter = {}
-
-        # reannounce_client is set when the agent id is
-        # first set. reannounce_client_instance ensures
-        # that once we start the announcement process we
-        # won't try another until we're finished
-        self.reannounce_client_request = None
+        self.reannouce_lock = DeferredLock()
 
     @classmethod
     def agent_api(cls):
@@ -228,72 +224,85 @@ class Agent(object):
         remaining = (datetime.utcnow() - contacted).total_seconds()
         return remaining > config["agent_master_reannounce"]
 
+    @inlineCallbacks
     def reannounce(self):
         """
         Method which is used to periodically contact the master.  This
         method is generally called as part of a scheduled task.
         """
+        yield self.reannouce_lock.acquire()
         if not self.should_reannounce():
-            return
+            yield self.reannouce_lock.release()
+            returnValue(None)
 
         svclog.debug("Announcing %s to master", config["agent_hostname"])
+        data = None
+        while True:  # for retries
+            try:
+                response = yield post_direct(
+                    self.agent_api(),
+                    data={
+                        "state": config["state"],
+                        "current_assignments": config.get(
+                            "current_assignments", {}),  # may not be set yet
+                        "free_ram": memory.free_ram()}
+                )
 
-        def callback(response):
-            if response.code == OK:
-                self.reannounce_client_request = None
-                config.master_contacted(announcement=True)
-                svclog.info("Announced self to the master server.")
-
-            elif response.code >= INTERNAL_SERVER_ERROR:
-                if not self.shutting_down:
-                    delay = http_retry_delay()
-                    svclog.warning(
-                        "Could not announce self to the master server, "
-                        "internal server error: %s.  Retrying in %s seconds.",
-                        response.data(), delay)
-                    reactor.callLater(delay, response.request.retry)
-                else:
-                    svclog.warning("Could not announce to master. Not retrying "
-                                   "because of pending shutdown")
-
-            elif response.code == NOT_FOUND:
-                self.reannounce_client_request = None
-                svclog.warning("The master says it does not know about our "
-                               "agent id. Posting as a new agent.")
-                self.post_agent_to_master()
-
-            # If this is a client problem retrying the request
-            # is unlikely to fix the issue so we stop here
-            elif response.code >= BAD_REQUEST:
-                self.reannounce_client_request = None
+            except Exception as error:
+                # Don't retry because reannounce is called periodically
                 svclog.error(
-                    "Failed to announce self to the master, bad "
-                    "request: %s.  This request will not be retried.",
-                    response.data())
+                    "Failed to announce self to the master: %s.  This "
+                    "request will not be retried.", error)
+                break
 
             else:
-                self.reannounce_client_request = None
-                svclog.error(
-                    "Unhandled error when posting self to the "
-                    "master: %s (code: %s).  This request will not be "
-                    "retried.", response.data(), response.code)
+                data = yield treq.json_content(response)
+                if response.code == OK:
+                    config.master_contacted(announcement=True)
+                    svclog.info("Announced self to the master server.")
+                    break
 
-        # In the event of a hard failure, do not retry because we'll
-        # be rerunning this code soon anyway.
-        def errback(failure):
-            self.reannounce_client_request = None
-            svclog.error(
-                "Failed to announce self to the master: %s.  This "
-                "request will not be retried.", failure)
+                elif response.code >= INTERNAL_SERVER_ERROR:
+                    if not self.shutting_down:
+                        delay = http_retry_delay()
+                        svclog.warning(
+                            "Could not announce self to the master server, "
+                            "internal server error: %s.  Retrying in %s "
+                            "seconds.", data, delay)
 
-        self.reannounce_client_request = post(
-            self.agent_api(),
-            callback=callback, errback=errback,
-            data={
-                "state": config["state"],
-                "current_assignments": config.get(
-                    "current_assignments", {}),  # may not be set yet
-                "free_ram": memory.free_ram()})
+                        deferred = Deferred()
+                        reactor.callLater(delay, deferred.callback, None)
+                        yield deferred
+                    else:
+                        svclog.warning(
+                            "Could not announce to master. Not retrying "
+                            "because of pending shutdown.")
+                        break
+
+                elif response.code == NOT_FOUND:
+                    svclog.warning("The master says it does not know about our "
+                                   "agent id. Posting as a new agent.")
+                    yield self.post_agent_to_master()
+                    break
+
+                # If this is a client problem retrying the request
+                # is unlikely to fix the issue so we stop here
+                elif response.code >= BAD_REQUEST:
+                    svclog.error(
+                        "Failed to announce self to the master, bad "
+                        "request: %s.  This request will not be retried.",
+                        data)
+                    break
+
+                else:
+                    svclog.error(
+                        "Unhandled error when posting self to the "
+                        "master: %s (code: %s).  This request will not be "
+                        "retried.", data, response.code)
+                    break
+
+        yield self.reannouce_lock.release()
+        returnValue(data)
 
     def system_data(self, requery_timeoffset=False):
         """

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -213,11 +213,7 @@ class Agent(object):
 
     def should_reannounce(self):
         """Small method which acts as a trigger for :meth:`reannounce`"""
-        if self.reannounce_client_request is not None:
-            svclog.debug("Agent is already trying to announce itself.")
-            return
-
-        if self.shutting_down:
+        if self.reannouce_lock.locked or self.shutting_down:
             return False
 
         contacted = config.master_contacted(update=False)

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -224,6 +224,7 @@ class Agent(object):
         remaining = (datetime.utcnow() - contacted).total_seconds()
         return remaining > config["agent_master_reannounce"]
 
+    @inlineCallbacks
     def reannounce(self, force=False):
         """
         Method which is used to periodically contact the master.  This

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -241,7 +241,7 @@ class Agent(object):
             yield self.reannounce_lock.acquire(
                 config["agent_master_reannounce"] * .70
             )
-        except utility.TimedDeferredLock:
+        except utility.LockTimeoutError:
             svclog.debug("Timed out while waiting to acquire reannounce_lock")
             returnValue(None)
 

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -86,7 +86,7 @@ class Agent(object):
         self.shutdown_timeout = None
         self.post_shutdown_lock = DeferredLock()
         self.stop_lock = DeferredLock()
-        self.reannouce_lock = DeferredLock()
+        self.reannounce_lock = DeferredLock()
         self.stopped = False
 
         # Register a callback so self.shutdown_timeout is set when
@@ -217,7 +217,7 @@ class Agent(object):
 
     def should_reannounce(self):
         """Small method which acts as a trigger for :meth:`reannounce`"""
-        if self.reannouce_lock.locked or self.shutting_down:
+        if self.reannounce_lock.locked or self.shutting_down:
             return False
 
         contacted = config.master_contacted(update=False)
@@ -233,9 +233,9 @@ class Agent(object):
         Method which is used to periodically contact the master.  This
         method is generally called as part of a scheduled task.
         """
-        yield self.reannouce_lock.acquire()
+        yield self.reannounce_lock.acquire()
         if not self.should_reannounce() and not force:
-            yield self.reannouce_lock.release()
+            yield self.reannounce_lock.release()
             returnValue(None)
 
         svclog.debug("Announcing %s to master", config["agent_hostname"])
@@ -304,7 +304,7 @@ class Agent(object):
                         "retried.", data, response.code)
                     break
 
-        yield self.reannouce_lock.release()
+        yield self.reannounce_lock.release()
         returnValue(data)
 
     def system_data(self, requery_timeoffset=False):

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -223,8 +223,9 @@ class Agent(object):
         contacted = config.master_contacted(update=False)
         if contacted is None:
             return True
-        remaining = (datetime.utcnow() - contacted).total_seconds()
-        return remaining > config["agent_master_reannounce"]
+
+        return utility.total_seconds(
+            datetime.utcnow() - contacted) > config["agent_master_reannounce"]
 
     @inlineCallbacks
     def reannounce(self, force=False):

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -54,7 +54,8 @@ except NameError:  # pragma: no cover
 
 from voluptuous import Schema, Any, Required, Optional, Invalid
 from twisted.internet import reactor
-from twisted.internet.defer import DeferredLock
+from twisted.internet.defer import AlreadyCalledError, DeferredLock, Deferred
+from twisted.internet.error import AlreadyCalled
 
 from pyfarm.core.enums import STRING_TYPES
 from pyfarm.agent.config import config
@@ -450,7 +451,39 @@ class TimedDeferredLock(DeferredLock):
     A subclass of :class:`DeferredLock` which has a timeout
     for the :meth:`acquire` call.
     """
-    def acquire(self, timeout):
+    def _timeout(self, deferred):
+        """
+        Raise a :class:`LockTimeoutError` in the given :class:`Deferred`
+        instance. This ensures that when a timeout is triggered it's
+        propagated all the way up the calling stack.
+        """
+        try:
+            raise LockTimeoutError
+        except LockTimeoutError as timeout:
+            deferred.errback(fail=timeout)
+
+    def _cancel_timeout(self, _, scheduled_call):
+        """
+        Cancels a scheduled call, ignoring cases where the event has already
+        been canceled.
+        """
+        try:
+            scheduled_call.cancel()
+        except AlreadyCalled:  # pragma: no cover
+            pass
+
+    def _call_callback(self, _, deferred):
+        """
+        Calls the callback() on the given deferred instance, ignoring cases
+        where it may already be called
+        """
+
+        try:
+            deferred.callback(None)
+        except AlreadyCalledError:  # pragma: no cover
+            pass
+
+    def acquire(self, timeout=None):
         """
         This method operates the same as :meth:`DeferredLock.acquire` does
         except it requires a timeout argument.
@@ -462,16 +495,19 @@ class TimedDeferredLock(DeferredLock):
             Raised if the timeout was reached before we could acquire
             the lock.
         """
-        assert isinstance(timeout, (int, float))
+        assert timeout is None or isinstance(timeout, (int, float))
+
         lock = DeferredLock.acquire(self)
+        if timeout is None:
+            return lock
 
-        def timeout_reached():
-            raise LockTimeoutError
+        # Schedule a call to trigger finished.errback() which will raise
+        # an exception.  If lock finishes first however cancel the timeout
+        # and unlock the lock by calling finished.
+        finished = Deferred()
+        lock.addCallback(
+            self._cancel_timeout,
+            reactor.callLater(timeout, self._timeout, finished))
+        lock.addCallback(self._call_callback, finished)
 
-        scheduled_call = reactor.callLater(timeout, timeout_reached)
-        lock.addBoth(lambda _: scheduled_call.cancel())
-
-        return lock
-
-
-
+        return finished

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -475,9 +475,9 @@ class TimedDeferredLock(DeferredLock):
     def _call_callback(self, _, deferred):
         """
         Calls the callback() on the given deferred instance, ignoring cases
-        where it may already be called
+        where it may already be called.  This can happen if acquire() has
+        already run.
         """
-
         try:
             deferred.callback(None)
         except AlreadyCalledError:  # pragma: no cover

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -495,7 +495,8 @@ class TimedDeferredLock(DeferredLock):
             Raised if the timeout was reached before we could acquire
             the lock.
         """
-        assert timeout is None or isinstance(timeout, (int, float))
+        assert timeout is None \
+            or isinstance(timeout, (int, float)) and timeout > 0
 
         lock = DeferredLock.acquire(self)
         if timeout is None:

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -1103,6 +1103,19 @@ class TestReannounce(TestCase):
             self.normal_result, 42
         )
 
+    @inlineCallbacks
+    def test_acquire_lock_timeout(self):
+        agent = Agent()
+        yield agent.reannounce_lock.acquire()
+        config["agent_master_reannounce"] = .1
+
+        with patch.object(svclog, "debug") as debug:
+            result = yield agent.reannounce()
+
+        self.assertIsNone(result)
+        debug.assert_called_with(
+            "Timed out while waiting to acquire reannounce_lock")
+
 
 class TestBuildHTTPResource(TestCase):
     def test_root_resources(self):

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -880,7 +880,6 @@ class TestStop(TestCase):
         stop_lock_release.assert_called_once()
 
 
-<<<<<<< HEAD
 class TestShouldReannounce(TestCase):
     POP_CONFIG_KEYS = [
         "agent_master_reannounce", "last_master_contact"

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -866,3 +866,18 @@ class TestReannounce(TestCase):
         acquire_lock.assert_called_once()
         release_lock.assert_called_once()
 
+    @inlineCallbacks
+    def test_should_not_reannounce_no_force(self):
+        agent = Agent()
+        with nested(
+            patch.object(agent, "should_reannounce", return_value=True),
+            patch.object(agent.reannouce_lock, "acquire"),
+            patch.object(agent.reannouce_lock, "release"),
+        ) as (should_reannounce, acquire_lock, release_lock):
+            result = yield agent.reannounce(force=False)
+
+        self.assertIsNone(result)
+        acquire_lock.assert_called_once()
+        release_lock.assert_called_once()
+
+    

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -887,7 +887,7 @@ class TestShouldReannounce(TestCase):
 
     def test_should_reannounce_locked(self):
         agent = Agent()
-        agent.reannouce_lock.acquire()
+        agent.reannounce_lock.acquire()
         self.assertFalse(agent.should_reannounce())
 
     def test_should_reannounce_shutting_down(self):
@@ -949,8 +949,8 @@ class TestReannounce(TestCase):
 
         with nested(
             patch.object(agent, "should_reannounce", return_value=False),
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release")
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release")
         ) as (_, acquire_lock, release_lock):
             result = yield agent.reannounce(force=False)
 
@@ -965,8 +965,8 @@ class TestReannounce(TestCase):
 
         with nested(
             patch.object(agent, "should_reannounce", return_value=False),
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release"),
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release"),
             patch.object(svclog, "debug")
         ) as (_, acquire_lock, release_lock, debug_log):
             result = yield agent.reannounce(force=True)
@@ -983,8 +983,8 @@ class TestReannounce(TestCase):
         agent = Agent()
 
         with nested(
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release")
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release")
         ) as (acquire_lock, release_lock):
             result = yield agent.reannounce(force=True)
 
@@ -999,8 +999,8 @@ class TestReannounce(TestCase):
         agent.shutting_down = True
 
         with nested(
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release"),
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release"),
             patch.object(svclog, "warning")
         ) as (acquire_lock, release_lock, warning_log):
             result = yield agent.reannounce(force=True)
@@ -1025,8 +1025,8 @@ class TestReannounce(TestCase):
         reactor.callLater(3, shutdown)
 
         with nested(
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release"),
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release"),
             patch.object(svclog, "warning")
         ) as (acquire_lock, release_lock, warning_log):
             result = yield agent.reannounce(force=True)
@@ -1048,8 +1048,8 @@ class TestReannounce(TestCase):
         post_deferred = Deferred()
         post_deferred.callback(None)
         with nested(
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release"),
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release"),
             patch.object(
                     agent, "post_agent_to_master", return_value=post_deferred),
         ) as (acquire_lock, release_lock, post_agent):
@@ -1066,8 +1066,8 @@ class TestReannounce(TestCase):
         agent = Agent()
 
         with nested(
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release"),
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release"),
             patch.object(svclog, "error")
         ) as (acquire_lock, release_lock, error_log):
             result = yield agent.reannounce(force=True)
@@ -1087,8 +1087,8 @@ class TestReannounce(TestCase):
         agent = Agent()
 
         with nested(
-            patch.object(agent.reannouce_lock, "acquire"),
-            patch.object(agent.reannouce_lock, "release"),
+            patch.object(agent.reannounce_lock, "acquire"),
+            patch.object(agent.reannounce_lock, "release"),
             patch.object(svclog, "error")
         ) as (acquire_lock, release_lock, error_log):
             result = yield agent.reannounce(force=True)

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -357,21 +357,22 @@ class TestTimedDeferredLock(TestCase):
         self.assertIsInstance(deferred, DeferredLock)
 
     @inlineCallbacks
-    def test_acquire(self):
+    def test_standard_behavior(self):
         deferred = TimedDeferredLock()
-
-        # Nothing else has acquired this lock, 0 should
-        # not cause a timeout
         yield deferred.acquire()
-
         self.assertTrue(deferred.locked)
         self.assertEqual(len(deferred.waiting), 0)
-
+        second_acquire = deferred.acquire()
+        self.assertTrue(deferred.locked)
+        self.assertEqual(len(deferred.waiting), 1)
+        self.assertFalse(second_acquire.called)
         yield deferred.release()
-
+        self.assertTrue(second_acquire.called)
+        self.assertTrue(deferred.locked)
+        self.assertEqual(len(deferred.waiting), 0)
+        yield deferred.release()
         self.assertFalse(deferred.locked)
         self.assertEqual(len(deferred.waiting), 0)
-
 
     @inlineCallbacks
     def test_acquire_timeout(self):

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -19,6 +19,7 @@ import shutil
 import os
 import re
 import tempfile
+from contextlib import nested
 from decimal import Decimal
 from datetime import datetime, timedelta
 from errno import ENOENT
@@ -26,7 +27,11 @@ from json import dumps as dumps_
 from uuid import UUID, uuid4
 from os.path import isfile, isdir
 
-from twisted.internet.defer import DeferredLock, inlineCallbacks
+from mock import Mock, patch
+from twisted.internet import reactor
+from twisted.internet.defer import (
+    AlreadyCalledError, DeferredLock, Deferred, inlineCallbacks)
+from twisted.internet.error import AlreadyCalled
 from voluptuous import Invalid
 
 from pyfarm.agent.config import config
@@ -356,6 +361,9 @@ class TestTimedDeferredLock(TestCase):
         deferred = TimedDeferredLock()
         self.assertIsInstance(deferred, DeferredLock)
 
+    def test_exception_parent_class(self):
+        self.assertIsInstance(LockTimeoutError(), Exception)
+
     @inlineCallbacks
     def test_standard_behavior(self):
         deferred = TimedDeferredLock()
@@ -377,9 +385,6 @@ class TestTimedDeferredLock(TestCase):
     @inlineCallbacks
     def test_acquire_timeout(self):
         deferred = TimedDeferredLock()
-
-        # Nothing else has acquired this lock, 0 should
-        # not cause a timeout
         yield deferred.acquire()
 
         self.assertTrue(deferred.locked)
@@ -392,4 +397,60 @@ class TestTimedDeferredLock(TestCase):
 
         self.assertTrue(1.1 > total_seconds(stop - start) > .9)
 
+    def test_assertion(self):
+        deferred = TimedDeferredLock()
 
+        for value in (-1, 0, "", datetime.utcnow()):
+            with self.assertRaises(AssertionError):
+                deferred.acquire(value)
+
+    @inlineCallbacks
+    def test_cancel_timeout(self):
+        deferred = TimedDeferredLock()
+
+        # Mock out the parts that will leak a Deferred object (which
+        # will cause the tests to fail)
+        with nested(
+            patch.object(reactor, "callLater"),
+            patch.object(deferred, "_cancel_timeout"),
+        ) as (callLater, cancel_timeout):
+            yield deferred.acquire()
+            deferred.acquire(10)
+            yield deferred.release()
+
+        self.assertEqual(callLater.call_count, 1)
+        timeout, timeout_method, finished = callLater.mock_calls[0][1]
+        self.assertEqual(timeout, 10)
+        self.assertIs(
+            timeout_method.im_func.func_name,
+            deferred._timeout.im_func.func_name)
+        self.assertIsInstance(finished, Deferred)
+
+    def test_private_call_callback_ignores_already_called_error(self):
+        deferred = TimedDeferredLock()
+
+        def raise_(_):
+            raise AlreadyCalledError
+
+        mock = Mock(callback=Mock(side_effect=raise_))
+        deferred._call_callback(None, mock)
+        mock.callback.assert_called_with(None)
+
+    def test_private_cancel_timeout_ignores_already_called(self):
+        deferred = TimedDeferredLock()
+
+        def raise_():
+            raise AlreadyCalled
+
+        mock = Mock(cancel=Mock(side_effect=raise_))
+        deferred._cancel_timeout(None, mock)
+        self.assertEqual(mock.cancel.call_count, 1)
+
+    def test_private_timeout(self):
+        deferred = TimedDeferredLock()
+        mock = Mock(errback=Mock())
+        deferred._timeout(mock)
+        self.assertEqual(mock.errback.call_count, 1)
+        keywords = mock.errback.mock_calls[0][2]
+        self.assertIn("fail", keywords)
+        self.assertIsInstance(keywords["fail"], LockTimeoutError)


### PR DESCRIPTION
As the title says, this pull request converts `reannounce()` to use `@inlineCallbacks.`