### PR TITLE
Update the agent state to running when necessary

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -233,12 +233,12 @@ class Agent(object):
         remaining = (datetime.utcnow() - contacted).total_seconds()
         return remaining > config["agent_master_reannounce"]
 
-    def reannounce(self):
+    def reannounce(self, force=False):
         """
         Method which is used to periodically contact the master.  This
         method is generally called as part of a scheduled task.
         """
-        if not self.should_reannounce():
+        if not self.should_reannounce() and not force:
             return
 
         svclog.debug("Announcing %s to master", config["agent_hostname"])


### PR DESCRIPTION
Also, change it back to online when no assignment is being worked on
anymore.

As a side effect, this will cause the free_ram value to be updated
immediately after the last active assignment has stopped running,
which is probably the most interesting point in time for getting a
free_ram update anyway.