### PR TITLE
remove_directory utility

### DIFF
--- a/pyfarm/agent/entrypoints/supervisor.py
+++ b/pyfarm/agent/entrypoints/supervisor.py
@@ -42,7 +42,7 @@ from pyfarm.agent.config import config
 from pyfarm.agent.entrypoints.parser import AgentArgumentParser
 from pyfarm.agent.entrypoints.utility import start_daemon_posix
 from pyfarm.agent.logger import getLogger
-from pyfarm.agent.utility import remove_file
+from pyfarm.agent.utility import remove_file, remove_directory
 
 logger = getLogger("agent.supervisor")
 
@@ -156,7 +156,7 @@ def supervisor():
                 zipfile.is_zipfile(update_file_path)):
                 logger.info("Found an upgrade to pyfarm-agent")
                 try:
-                    shutil.rmtree(args.agent_package_dir)
+                    remove_directory(args.agent_package_dir, raise_=True)
                     os.makedirs(args.agent_package_dir)
                     with zipfile.ZipFile(update_file_path, "r") as archive:
                         archive.extractall(args.agent_package_dir)

--- a/pyfarm/agent/entrypoints/supervisor.py
+++ b/pyfarm/agent/entrypoints/supervisor.py
@@ -19,7 +19,6 @@ import signal
 import subprocess
 import sys
 import time
-import shutil
 import zipfile
 from os.path import join, isdir, isfile
 

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -47,6 +47,7 @@ from pyfarm.core.enums import AgentState, PY26, STRING_TYPES
 from pyfarm.agent.http.core.client import post
 from pyfarm.agent.config import config, logger as config_logger
 from pyfarm.agent.sysinfo import memory, cpu
+from pyfarm.agent.utility import remove_directory
 
 try:
     from unittest.case import _AssertRaisesContext
@@ -442,13 +443,6 @@ class TestCase(_TestCase):
             "agent_html_template_reload": True,
             "agent_master_reannounce": randint(5, 15)})
 
-    def _rmdir(self, path, on_exit=True):
-        try:
-            shutil.rmtree(path)
-        except (IOError, OSError):
-            if on_exit:
-                atexit.register(self._rmdir, path, on_exit=False)
-
     def create_file(self, content=None, dir=None, suffix=""):
         """
         Creates a test file on disk using :func:`tempfile.mkstemp`
@@ -480,7 +474,8 @@ class TestCase(_TestCase):
 
     def create_directory(self, count=10):
         directory = tempfile.mkdtemp()
-        self.addCleanup(self._rmdir, directory)
+        self.addCleanup(
+            remove_directory, directory, retry_on_exit=True, raise_=False)
 
         files = []
         for _ in range(count):

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -431,7 +431,7 @@ def remove_directory(
             keywords = dict(retry_on_exit=False, raise_=False)
             signature = (remove_directory, (path, ), keywords)
             if signature not in atexit._exithandlers:
-                atexit.register(remove_file, path, **keywords)
+                atexit.register(remove_directory, path, **keywords)
         else:
             logger.error(
                 "Failed to remove %s (%s)",

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -370,8 +370,6 @@ def remove_file(
         os.remove(path)
     except (WindowsError, OSError, IOError) as error:
         if error.errno in ignored_errnos:
-            logger.debug(
-                "Failed to remove %s (%s)", path, errorcode[error.errno])
             return
 
         if retry_on_exit:
@@ -418,8 +416,6 @@ def remove_directory(
         shutil.rmtree(path)
     except (WindowsError, OSError, IOError) as error:
         if error.errno in ignored_errnos:
-            logger.debug(
-                "Failed to remove %s (%s)", path, errorcode[error.errno])
             return
 
         if retry_on_exit:

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -408,7 +408,7 @@ def remove_directory(
 
     :param bool raise_:
         If True, raise an exceptions produced.  This will always be
-        False if :func:`remove_file` is being executed by :module:`atexit`
+        False if :func:`remove_directory` is being executed by :module:`atexit`
 
     :param tuple ignored_errnos:
         A tuple of ignored error numbers.  By default this function

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -398,8 +398,8 @@ def remove_file(
 def remove_directory(
         path, retry_on_exit=False, raise_=True, ignored_errnos=(ENOENT, )):
     """
-    Simple function to remove the provided directory or retry on exit
-    if requested.  This function standardizes the log output, ensures
+    Simple function to **recursively** remove the provided directory or retry on
+    exit if requested.  This function standardizes the log output, ensures
     it's only called once per path on exit and handles platform
     specific exceptions (ie. ``WindowsError``).
 

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -26,6 +26,7 @@ import atexit
 import csv
 import codecs
 import os
+import shutil
 from decimal import Decimal
 from datetime import datetime, timedelta
 from errno import EEXIST, ENOENT, errorcode
@@ -381,6 +382,54 @@ def remove_file(
             # Make sure we're not added multiple times
             keywords = dict(retry_on_exit=False, raise_=False)
             signature = (remove_file, (path, ), keywords)
+            if signature not in atexit._exithandlers:
+                atexit.register(remove_file, path, **keywords)
+        else:
+            logger.error(
+                "Failed to remove %s (%s)",
+                path, errorcode[error.errno])
+
+        if raise_:
+            raise
+    else:
+        logger.info("Removed %s", path)
+
+
+def remove_directory(
+        path, retry_on_exit=False, raise_=True, ignored_errnos=(ENOENT, )):
+    """
+    Simple function to remove the provided directory or retry on exit
+    if requested.  This function standardizes the log output, ensures
+    it's only called once per path on exit and handles platform
+    specific exceptions (ie. ``WindowsError``).
+
+    :param bool retry_on_exit:
+        If True, retry removal of the file when Python exists.
+
+    :param bool raise_:
+        If True, raise an exceptions produced.  This will always be
+        False if :func:`remove_file` is being executed by :module:`atexit`
+
+    :param tuple ignored_errnos:
+        A tuple of ignored error numbers.  By default this function
+        only ignores ENOENT.
+    """
+    try:
+        shutil.rmtree(path)
+    except (WindowsError, OSError, IOError) as error:
+        if error.errno in ignored_errnos:
+            logger.debug(
+                "Failed to remove %s (%s)", path, errorcode[error.errno])
+            return
+
+        if retry_on_exit:
+            logger.warning(
+                "Failed to remove %s (%s), will retry on exit",
+                path, errorcode[error.errno])
+
+            # Make sure we're not added multiple times
+            keywords = dict(retry_on_exit=False, raise_=False)
+            signature = (remove_directory, (path, ), keywords)
             if signature not in atexit._exithandlers:
                 atexit.register(remove_file, path, **keywords)
         else:

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 from errno import ENOENT
 from json import dumps as dumps_
 from uuid import UUID, uuid4
-from os.path import isfile
+from os.path import isfile, isdir
 
 from mock import patch
 from voluptuous import Invalid
@@ -33,7 +33,7 @@ from pyfarm.agent.testutil import TestCase, FakeRequest
 from pyfarm.agent.utility import (
     UnicodeCSVWriter, UnicodeCSVReader, default_json_encoder, dumps,
     quote_url, request_from_master, total_seconds, validate_environment,
-    AgentUUID, remove_file, logger)
+    AgentUUID, remove_file, logger, remove_directory)
 
 try:
     WindowsError
@@ -303,3 +303,48 @@ class TestRemoveFile(TestCase):
             self.path, ignored_errnos=(), retry_on_exit=True, raise_=False)
         self.assertEqual(atexit._exithandlers, self.atexit_signature)
 
+
+class TestRemoveDirectory(TestCase):
+    def setUp(self):
+        super(TestRemoveDirectory, self).setUp()
+        path = tempfile.mkdtemp()
+        self.path = path
+        del atexit._exithandlers[:]
+        self.atexit_signature = [
+            (remove_directory, (self.path, ),
+             {"raise_": False, "retry_on_exit": False})]
+
+    def test_removes_directory(self):
+        remove_directory(self.path)
+        self.assertFalse(isdir(self.path))
+
+    def test_ignored_error(self):
+        os.rmdir(self.path)
+        remove_directory(self.path, ignored_errnos=(ENOENT, ), raise_=True)
+        self.assertFalse(isdir(self.path))
+
+    def test_retry_on_shutdown_no_raise(self):
+        os.rmdir(self.path)
+        remove_directory(
+            self.path, ignored_errnos=(), retry_on_exit=True, raise_=False)
+        self.assertEqual(atexit._exithandlers, self.atexit_signature)
+
+    def test_retry_on_shutdown_raise(self):
+        os.rmdir(self.path)
+
+        with self.assertRaises((WindowsError, OSError, IOError)):
+            remove_directory(
+                self.path, ignored_errnos=(), retry_on_exit=True, raise_=True)
+
+        self.assertEqual(atexit._exithandlers, self.atexit_signature)
+
+    def test_retry_only_once(self):
+        os.rmdir(self.path)
+
+        # If remove_file is wrapped in a while loop and is being
+        # passed the same arguments, it should only be one call for atexit.
+        remove_directory(
+            self.path, ignored_errnos=(), retry_on_exit=True, raise_=False)
+        remove_directory(
+            self.path, ignored_errnos=(), retry_on_exit=True, raise_=False)
+        self.assertEqual(atexit._exithandlers, self.atexit_signature)


### PR DESCRIPTION
This is a complimentary function to `utility.remove_file()`.  Adding this for use in tests mainly but also for job type implementors too.