### PR TITLE
More test coverage for pyfarm.agent.utility

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,6 +13,7 @@ exclude_lines =
     log.*\.debug.*
     log.*\.info.*
     log.*\.warning.*
+    log.*\.error.*
     log.*\.critical.*
     log.*\.fatal.*
     log.*\.log.*

--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -290,7 +290,7 @@ class AgentUUID(object):
 
             return UUID(data)
 
-        except (OSError, IOError) as e:
+        except (WindowsError, OSError, IOError) as e:
             if e.errno == ENOENT:
                 cls.log.warning("UUID file %s does not exist.", path)
                 return None
@@ -331,7 +331,7 @@ class AgentUUID(object):
 
             cls.log.debug("Cached %s to %r", agent_uuid, path)
 
-        except (OSError, IOError) as e:  # pragma: no cover
+        except (WindowsError, OSError, IOError) as e:  # pragma: no cover
             cls.log.error("Failed to write %s, %s", path, e)
             raise
 

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -25,7 +25,6 @@ from json import dumps as dumps_
 from uuid import UUID, uuid4
 from os.path import isfile
 
-from mock import patch
 from voluptuous import Invalid
 
 from pyfarm.agent.config import config
@@ -33,7 +32,7 @@ from pyfarm.agent.testutil import TestCase, FakeRequest
 from pyfarm.agent.utility import (
     UnicodeCSVWriter, UnicodeCSVReader, default_json_encoder, dumps,
     quote_url, request_from_master, total_seconds, validate_environment,
-    AgentUUID, remove_file, logger)
+    AgentUUID, remove_file, validate_uuid)
 
 try:
     WindowsError
@@ -54,6 +53,25 @@ class TestValidateEnvironment(TestCase):
     def test_key(self):
         with self.assertRaisesRegexp(Invalid, re.compile("Key.*string.*")):
             validate_environment({1: None})
+
+
+class TestValidateUUID(TestCase):
+    def test_uuid(self):
+        uid = uuid4()
+        self.assertIs(validate_uuid(uid), uid)
+
+    def test_hex(self):
+        uid = uuid4()
+        self.assertEqual(validate_uuid(uid.hex).hex, uid.hex)
+
+    def test_invalid_hex(self):
+        with self.assertRaises(Invalid):
+            validate_uuid("hello world")
+
+    def test_other_invalid(self):
+        for value in (None, True, lambda: None, 1):
+            with self.assertRaises(Invalid):
+                validate_uuid(value)
 
 
 class TestDefaultJsonEncoder(TestCase):

--- a/tests/test_agent/test_utility.py
+++ b/tests/test_agent/test_utility.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import atexit
+import shutil
 import os
 import re
 import tempfile
@@ -246,6 +247,13 @@ class TestAgentUUID(TestCase):
         path = self.create_file()
         os.remove(path)
         self.assertIsNone(AgentUUID.load(path))
+
+    def test_raises_unhandled_error(self):
+        path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, path)
+
+        with self.assertRaises(IOError):
+            AgentUUID.load(path)
 
 
 class TestRemoveFile(TestCase):


### PR DESCRIPTION
This PR does three things:
* Adds some missing tests for `pyfarm.agent.utility`
* Ensures that we also handle `WindowsError` when dealing with files
* Adds missing coverage exclusion for `logger.errror`