### PR TITLE
Upload logs after the assignment has finished

### DIFF
--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -289,6 +289,8 @@ class Assign(APIResource):
                     lambda *args: instance._remove_tempdirs())
                 stopped_deferred.addBoth(
                     lambda *args: instance._close_logs())
+                stopped_deferred.addBoth(
+                    lambda *args: instance._upload_logfile())
             except Exception as e:
                 logger.error("Error on starting jobtype, stopping it now.  "
                              "Error was: %s", e)

--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -475,17 +475,9 @@ class Process(object):
 
         # If there are no processes running at this point, we assume
         # the assignment is finished
-        upload_deferred = None
         if len(self.processes) == 0:
-            if not self.failed_processes:
-                logger.info("Processes in assignment %s stopped, no failures",
-                            self)
-            else:
-                logger.warning("There was at least one failed process in the "
-                               "assignment %s", self)
-            upload_deferred = self._upload_logfile(self.log_identifier)
             self.stopped_deferred.callback(None)
-        return upload_deferred or succeed([])
+        return succeed([])
 
     def _spawn_process(self, command):
         """
@@ -624,13 +616,13 @@ class Process(object):
         for task in self.assignment["tasks"]:
             post_logfile(task, log_path)
 
-    def _upload_logfile(self, log_identifier):
-        path = join(config["jobtype_task_logs"], log_identifier)
+    def _upload_logfile(self):
+        path = join(config["jobtype_task_logs"], self.log_identifier)
         url = "%s/jobs/%s/tasks/%s/attempts/%s/logs/%s/logfile" % (
                 config["master_api"], self.assignment["job"]["id"],
                 self.assignment["tasks"][0]["id"],
                 self.assignment["tasks"][0]["attempt"],
-                log_identifier)
+                self.log_identifier)
         upload_deferred = Deferred()
 
         def upload(url, log_identifier, delay=0):
@@ -692,9 +684,9 @@ class Process(object):
                 log_identifier, failure_reason, delay)
             upload(url, log_identifier, delay=delay)
 
-        logger.info("Uploading log file %s to master, URL %r", log_identifier,
-                    url)
-        upload(url, log_identifier)
+        logger.info("Uploading log file %s to master, URL %r",
+                    self.log_identifier, url)
+        upload(url, self.log_identifier)
         return upload_deferred
 
 


### PR DESCRIPTION
This avoids a situation where the log has not been closed yet and might
still be written to while being uploaded.

As a side effect, _upload_logfile() now no longer takes a log
identifier, since an assignment is only supposed to have one log anyway.