### PR TITLE
Catch exceptions from JobType.is_successful()

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -456,7 +456,7 @@ class Process(object):
         process_data = self.processes.pop(protocol.uuid)
 
         try:
-            successful = self.is_successful(reason)
+            successful = self.is_successful(protocol, reason)
         except Exception as e:
             logger.error("Exception caught from is_successful: %s: \"%s\". "
                          "Assuming not successful.", e.__class__.__name__, e)

--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -458,10 +458,10 @@ class Process(object):
         try:
             successful = self.is_successful(protocol, reason)
         except Exception as e:
-            logger.error("Exception caught from is_successful: %s: \"%s\". "
-                         "Assuming not successful.", e.__class__.__name__, e)
-            self._log("Exception caught from is_successful: %s: \"%s\". "
-                      "Assuming not successful." % (e.__class__.__name__, e))
+            message = ("Exception caught from is_successful(): %r. "
+                       "Assuming not successful." % e)
+            logger.error(message)
+            self._log(message)
             successful = False
         if successful:
             logpool.log(

--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -455,7 +455,15 @@ class Process(object):
         logger.info("%r stopped (code: %r)", protocol, reason.value.exitCode)
         process_data = self.processes.pop(protocol.uuid)
 
-        if self.is_successful(reason):
+        try:
+            successful = self.is_successful(reason)
+        except Exception as e:
+            logger.error("Exception caught from is_successful: %s: \"%s\". "
+                         "Assuming not successful.", e.__class__.__name__, e)
+            self._log("Exception caught from is_successful: %s: \"%s\". "
+                      "Assuming not successful." % (e.__class__.__name__, e))
+            successful = False
+        if successful:
             logpool.log(
                 self.uuid, "internal",
                 "Process has terminated successfully, code %s" %

--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -918,7 +918,7 @@ class JobType(Cache, System, Process, TypeChecks):
         else:
             return None
 
-    def is_successful(self, reason):
+    def is_successful(self, protocol, reason):
         """
         **Overridable**.  This method that determines whether the process
         referred to by a protocol instance has exited successfully.


### PR DESCRIPTION
JobType.is_successful() is user-overridable, so we have to assume it
might raise an exception.

The previous code would fail to call the stopped deferred is that
happened, resulting in the agent hanging.