### PR TITLE
TypeChecks Cleanup/Improvements

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -829,6 +829,7 @@ class System(object):
         """
         logpool.log(self.uuid, "jobtype", message)
 
+
 class TypeChecks(object):
     def _check_expandvars_inputs(self, value, environment):
         """Checks input arguments for :meth:`expandvars`"""

--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -831,7 +831,12 @@ class System(object):
 
 
 class TypeChecks(object):
-    def _check_expandvars_inputs(self, value, environment):
+    """
+    Helper static methods for performing type checks on
+    input arguments.
+    """
+    @staticmethod
+    def _check_expandvars_inputs(value, environment):
         """Checks input arguments for :meth:`expandvars`"""
         if not isinstance(value, STRING_TYPES):
             raise TypeError("Expected a string for `value`")
@@ -839,12 +844,14 @@ class TypeChecks(object):
         if environment is not None and not isinstance(environment, dict):
             raise TypeError("Expected None or a dictionary for `environment`")
 
-    def _check_map_path_inputs(self, path):
+    @staticmethod
+    def _check_map_path_inputs(path):
         """Checks input arguments for :meth:`map_path`"""
         if not isinstance(path, STRING_TYPES):
             raise TypeError("Expected string for `path`")
 
-    def _check_csvlog_path_inputs(self, protocol_uuid, now):
+    @staticmethod
+    def _check_csvlog_path_inputs(protocol_uuid, now):
         """Checks input arguments for :meth:`get_csvlog_path`"""
         if not isinstance(protocol_uuid, UUID):
             raise TypeError("Expected UUID for `protocol_uuid`")
@@ -852,12 +859,14 @@ class TypeChecks(object):
         if now is not None and not isinstance(now, datetime):
             raise TypeError("Expected None or datetime for `now`")
 
-    def _check_command_list_inputs(self, cmdlist):
+    @staticmethod
+    def _check_command_list_inputs(cmdlist):
         """Checks input arguments for :meth:`get_command_list`"""
         if not isinstance(cmdlist, (tuple, list)):
             raise TypeError("Expected tuple or list for `cmdlist`")
 
-    def _check_set_states_inputs(self, tasks, state):
+    @staticmethod
+    def _check_set_states_inputs(tasks, state):
         """Checks input arguments for :meth:`set_states`"""
         if not isinstance(tasks, ITERABLE_CONTAINERS):
             raise TypeError("Expected tuple, list or set for `tasks`")

--- a/tests/test_jobtypes/test_core_internals.py
+++ b/tests/test_jobtypes/test_core_internals.py
@@ -262,120 +262,60 @@ class TestProcess(TestCase):
                         "username", "get_uid", pwd, "pwd"))
 
 
-# TODO: fix these tests to use the new CommandData.validate
-# class TestSpawnProcessTypeChecks(TestCase):
-    # def test_command(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(TypeError, ".*for.*command.*"):
-    #         checks._check_spawn_process_inputs(
-    #             None, None, None, None, None, None)
-    #
-    # def test_arguments(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(TypeError, ".*for.*arguments.*"):
-    #         checks._check_spawn_process_inputs(
-    #             "", None, None, None, None, None)
-    #
-    # def test_workdir_not_string(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(TypeError, ".*for.*working_.*"):
-    #         checks._check_spawn_process_inputs(
-    #             "", [], None, None, None, None)
-    #
-    # def test_workdir_missing(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaises(OSError):
-    #         checks._check_spawn_process_inputs(
-    #             "", [], urandom(8).encode("hex"), {}, "foo", "foo")
-    #
-    # def test_environment(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(TypeError, ".*for.*environment.*"):
-    #         checks._check_spawn_process_inputs(
-    #             "", [], gettempdir(), None, None, None)
-    #
-    # def test_user(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(TypeError, ".*for.*user.*"):
-    #         checks._check_spawn_process_inputs(
-    #             "", [], gettempdir(), {}, bool, None)
-    #
-    # def test_group(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(TypeError, ".*for.*group.*"):
-    #         checks._check_spawn_process_inputs(
-    #             "", [], gettempdir(), {}, 0, bool)
-    #
-    # @skipIf(is_administrator() or WINDOWS, "Cannot run on Windows or as root")
-    # def test_cannot_change_user(self):
-    #     checks = TypeChecks()
-    #     with self.assertRaisesRegexp(EnvironmentError, ".*change user or.*"):
-    #         checks._check_spawn_process_inputs(
-    #             "", [], gettempdir(), {}, "foo", "foo")
-
-
-class TestMiscTypeChecks(TestCase):
+class TestTypeChecks(TestCase):
     def test_expandvars_value_not_string(self):
-        checks = TypeChecks()
-        checks._check_expandvars_inputs("", {})
+        TypeChecks._check_expandvars_inputs("", {})
 
         with self.assertRaisesRegexp(TypeError,
                                      re.compile(".*for.*value.*")):
-            checks._check_expandvars_inputs(None, None)
+            TypeChecks._check_expandvars_inputs(None, None)
 
     def test_expandvars_environment_not_dict(self):
-        checks = TypeChecks()
-        checks._check_expandvars_inputs("", None)
+        TypeChecks._check_expandvars_inputs("", None)
 
         with self.assertRaisesRegexp(TypeError,
                                      re.compile(".*for.*environment.*")):
-            checks._check_expandvars_inputs("", 1)
+            TypeChecks._check_expandvars_inputs("", 1)
 
     def test_map(self):
-        checks = TypeChecks()
         for objtype in STRING_TYPES:
-            checks._check_map_path_inputs(objtype())
+            TypeChecks._check_map_path_inputs(objtype())
 
         with self.assertRaisesRegexp(TypeError, re.compile(".*for.*path.*")):
-            checks._check_map_path_inputs(None)
+            TypeChecks._check_map_path_inputs(None)
 
     def test_csvlog_path_tasks(self):
-        checks = TypeChecks()
-        checks._check_csvlog_path_inputs(uuid4(), None)
+        TypeChecks._check_csvlog_path_inputs(uuid4(), None)
 
         with self.assertRaisesRegexp(
                 TypeError, re.compile("Expected UUID for `protocol_uuid`")):
-            checks._check_csvlog_path_inputs(None, None)
+            TypeChecks._check_csvlog_path_inputs(None, None)
 
     def test_csvlog_path_time(self):
-        checks = TypeChecks()
-        checks._check_csvlog_path_inputs(uuid4(), None)
+        TypeChecks._check_csvlog_path_inputs(uuid4(), None)
 
         with self.assertRaisesRegexp(
                 TypeError, re.compile("Expected UUID for `protocol_uuid`")):
-            checks._check_csvlog_path_inputs([], "")
+            TypeChecks._check_csvlog_path_inputs([], "")
 
     def test_command_list(self):
-        checks = TypeChecks()
-        checks._check_command_list_inputs(tuple())
-        checks._check_command_list_inputs([])
+        TypeChecks._check_command_list_inputs(tuple())
+        TypeChecks._check_command_list_inputs([])
 
         with self.assertRaisesRegexp(TypeError, re.compile(".*for.*cmdlist.*")):
-            checks._check_command_list_inputs(None)
+            TypeChecks._check_command_list_inputs(None)
 
     def test_set_state_tasks(self):
-        checks = TypeChecks()
         for objtype in ITERABLE_CONTAINERS:
-            checks._check_set_states_inputs(objtype(), WorkState.DONE)
+            TypeChecks._check_set_states_inputs(objtype(), WorkState.DONE)
 
         with self.assertRaisesRegexp(TypeError, re.compile(".*for.*tasks.*")):
-            checks._check_set_states_inputs(None, None)
+            TypeChecks._check_set_states_inputs(None, None)
 
     def test_set_state_state(self):
-        checks = TypeChecks()
         for state in WorkState:
-            checks._check_set_states_inputs(ITERABLE_CONTAINERS[0](), state)
+            TypeChecks._check_set_states_inputs(ITERABLE_CONTAINERS[0](), state)
 
         with self.assertRaisesRegexp(ValueError,
                                      re.compile(".*Expected.*state.*")):
-            checks._check_set_states_inputs(ITERABLE_CONTAINERS[0](), None)
+            TypeChecks._check_set_states_inputs(ITERABLE_CONTAINERS[0](), None)

--- a/tests/test_jobtypes/test_core_internals.py
+++ b/tests/test_jobtypes/test_core_internals.py
@@ -295,8 +295,8 @@ class TestTypeChecks(TestCase):
         TypeChecks._check_csvlog_path_inputs(uuid4(), None)
 
         with self.assertRaisesRegexp(
-                TypeError, re.compile("Expected UUID for `protocol_uuid`")):
-            TypeChecks._check_csvlog_path_inputs([], "")
+                TypeError, re.compile("Expected None or datetime for `now`")):
+            TypeChecks._check_csvlog_path_inputs(uuid4(), "")
 
     def test_command_list(self):
         TypeChecks._check_command_list_inputs(tuple())


### PR DESCRIPTION
These is a non-functional change that makes some small improvements to the `TypeChecks` class.  The main change is switching to `@staticmethod` since we don't need access to either the class or the instance.  This change also removes some tests which are no longer valid or are already covered by other tests.