### PR TITLE
Change Config Logging to Debug

### DIFF
--- a/pyfarm/agent/config.py
+++ b/pyfarm/agent/config.py
@@ -266,7 +266,7 @@ class ConfigurationWithCallbacks(LoggingConfiguration):
         callbacks = cls.callbacks.setdefault(key, [])
 
         if callback in callbacks and not append:
-            logger.warning(
+            logger.debug(
                 "%r is already a registered callback for %r", callback, key)
             return
 
@@ -280,7 +280,7 @@ class ConfigurationWithCallbacks(LoggingConfiguration):
         """
         results = cls.callbacks.pop(key, None)
         if results is None:  # pragma: no cover
-            logger.warning(
+            logger.debug(
                 "%r is not a registered callback for %r", callback, key)
 
     def clear(self, callbacks=False):

--- a/pyfarm/agent/config.py
+++ b/pyfarm/agent/config.py
@@ -204,13 +204,13 @@ class LoggingConfiguration(Configuration):
         assert old_value is NOTSET if change_type == self.CREATED else True
 
         if change_type == self.MODIFIED:
-            logger.info("modified %r = %r", key, new_value)
+            logger.debug("modified %r = %r", key, new_value)
 
         elif change_type == self.CREATED:
-            logger.info("set %r = %r", key, new_value)
+            logger.debug("set %r = %r", key, new_value)
 
         elif change_type == self.DELETED:
-            logger.warning("deleted %r", key)
+            logger.debug("deleted %r", key)
 
         else:
             raise NotImplementedError(

--- a/pyfarm/agent/config.py
+++ b/pyfarm/agent/config.py
@@ -204,13 +204,13 @@ class LoggingConfiguration(Configuration):
         assert old_value is NOTSET if change_type == self.CREATED else True
 
         if change_type == self.MODIFIED:
-            logger.debug("modified %r = %r", key, new_value)
+            logger.debug("Modified %r = %r", key, new_value)
 
         elif change_type == self.CREATED:
-            logger.debug("set %r = %r", key, new_value)
+            logger.debug("Set %r = %r", key, new_value)
 
         elif change_type == self.DELETED:
-            logger.debug("deleted %r", key)
+            logger.debug("Deleted %r", key)
 
         else:
             raise NotImplementedError(


### PR DESCRIPTION
This change changes all logging calls in the config object to debug to cut down on logging output.  Full comment from 7709711506affb0e2f8fc02155168d2efa79d3c0:

```
The agent's configuration logger is probably
one of the most verbose loggers.  Its output
is important but probably only in cases where
there's a problem being debugged.  Even then the
configuration is usually not going to be the cause
of the issue so keeping the configuration logger
in debug only mode probably makes more sense.
```