### PR TITLE
Configuration Based Logger Level

### DIFF
--- a/pyfarm/agent/config.py
+++ b/pyfarm/agent/config.py
@@ -329,9 +329,9 @@ def configure_logger_level():
     assert isinstance(root_level, int)
 
     levels = CONFIGURATION["levels"]
-    for i, (name, level) in enumerate(levels):
+    for index, (name, level) in enumerate(levels):
         if name == "":
-            levels[0] = ("", root_level)
+            levels[index] = ("", root_level)
             break
     else:
         levels.insert(0, ("", root_level))

--- a/pyfarm/agent/etc/agent.yml
+++ b/pyfarm/agent/etc/agent.yml
@@ -80,6 +80,10 @@ agent_api_port: 50000
 agent_log: $agent_logs_root/agent.log
 supervisor_log: $agent_logs_root/supervisor.log
 
+# Controls the log level for all loggers.  Valid levels
+# are 'debug', 'info', 'warning', 'error' and 'critical'.
+agent_global_logger_level: info
+
 # The user agent the master will use when connecting to the agent's
 # REST api.  This value should only be changed if the master's code
 # is updated with a new user agent.  Change this value has not effect

--- a/pyfarm/agent/logger/twistd.py
+++ b/pyfarm/agent/logger/twistd.py
@@ -44,11 +44,10 @@ CONFIGURATION = {
     "datefmt": "%Y-%m-%d %H:%M:%S",
     "format": "%(asctime)s %(levelname)-8s - %(name)-15s - %(message)s",
 
-    # Defines the cutoff level for different loggers.  By default
-    # the only defined cutoff is for root ("").  Logger names
+    # Defines the cutoff level for different loggers.  Logger names
     # should be defined using *'s to define matches.
     "levels": [
-        ("", DEBUG),
+        ("", INFO),
         ("HTTP11ClientProtocol*", INFO)]}
 
 # Only setup colorama if we're not inside

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -358,7 +358,7 @@ class TestCase(_TestCase):
 
     def setUp(self):
         super(TestCase, self).setUp()
-        self._config_logger_disabed = config_logger.disabled
+        self._config_logger_disabled = config_logger.disabled
         config_logger.disabled = True
 
         try:
@@ -380,7 +380,7 @@ class TestCase(_TestCase):
 
     def tearDown(self):
         super(TestCase, self).tearDown()
-        config_logger.disabled = self._config_logger_disabed
+        config_logger.disabled = self._config_logger_disabled
 
     def prepare_config(self):
         for key in self._pop_config_keys:

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -91,7 +91,6 @@ from twisted.internet.defer import Deferred, succeed
 from pyfarm.agent.entrypoints.parser import AgentArgumentParser
 from pyfarm.agent.http.api.base import APIResource
 
-ENABLE_LOGGING = read_env_bool("PYFARM_AGENT_TEST_LOGGING", False)
 PYFARM_AGENT_MASTER = read_env("PYFARM_AGENT_TEST_MASTER", "127.0.0.1:80")
 
 if ":" not in PYFARM_AGENT_MASTER:
@@ -359,6 +358,8 @@ class TestCase(_TestCase):
 
     def setUp(self):
         super(TestCase, self).setUp()
+        self._config_logger_disabed = config_logger.disabled
+        config_logger.disabled = True
 
         try:
             self._pop_config_keys
@@ -375,13 +376,11 @@ class TestCase(_TestCase):
             "last_master_contact"])
 
         DelayedCall.debug = True
-        if not ENABLE_LOGGING:
-            logging.getLogger("pf").setLevel(logging.CRITICAL)
-
-        config_logger_disabled = config_logger.disabled
-        config_logger.disabled = True
         self.prepare_config()
-        config_logger.disabled = config_logger_disabled
+
+    def tearDown(self):
+        super(TestCase, self).tearDown()
+        config_logger.disabled = self._config_logger_disabed
 
     def prepare_config(self):
         for key in self._pop_config_keys:

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -356,10 +356,13 @@ class TestCase(_TestCase):
         def skipTest(self, reason):
             raise SkipTest(reason)
 
+    # If the config logger really needs to be turned on someone
+    # can do so in setUp.  This is pretty verbose and will make
+    # it difficult to debug tests.
+    config_logger.disabled = True
+
     def setUp(self):
         super(TestCase, self).setUp()
-        self._config_logger_disabled = config_logger.disabled
-        config_logger.disabled = True
 
         try:
             self._pop_config_keys
@@ -377,10 +380,6 @@ class TestCase(_TestCase):
 
         DelayedCall.debug = True
         self.prepare_config()
-
-    def tearDown(self):
-        super(TestCase, self).tearDown()
-        config_logger.disabled = self._config_logger_disabled
 
     def prepare_config(self):
         for key in self._pop_config_keys:


### PR DESCRIPTION
This change adds the `agent_global_logger_level` configuration variable.  The main purpose of this variable is to provide some control over the global logging level.  

The only side effect that I know of with this change is we'll miss a few debug level messages from just prior to the config loading because the default level is now INFO in `twistd.py`.  This is probably fixable with a couple of work arounds but I don't think we're going to be missing much because the config module is almost always one of the first modules to load.