### PR TITLE
Improve testutil setUp

### DIFF
--- a/pyfarm/agent/etc/agent.yml
+++ b/pyfarm/agent/etc/agent.yml
@@ -185,7 +185,6 @@ agent_manhole_password: admin
 # NOTE: The following values are used by the unittests and should be
 # generally ignored for anything other than development.
 agent_unittest:
-  dns_test_hostname: example.com
   client_redirect_target: http://example.com
   client_api_test_url_https: https://httpbin.pyfarm.net
   client_api_test_url_http: http://httpbin.pyfarm.net

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -14,13 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import atexit
-import logging
 import os
 import re
 import socket
 import sys
-import shutil
 import tempfile
 import time
 import uuid
@@ -43,7 +40,7 @@ from twisted.internet.base import DelayedCall
 from twisted.trial.unittest import TestCase as _TestCase, SkipTest, FailTest
 from twisted.web.test.requesthelper import DummyRequest as _DummyRequest
 
-from pyfarm.core.config import read_env, read_env_bool
+from pyfarm.core.config import read_env
 from pyfarm.core.enums import AgentState, PY26, STRING_TYPES
 from pyfarm.agent.http.core.client import post
 from pyfarm.agent.config import config, logger as config_logger

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -475,7 +475,6 @@ class BaseRequestTestCase(TestCase):
         finally:
             socket.setdefaulttimeout(DEFAULT_SOCKET_TIMEOUT)
 
-
     def setUp(self):
         if not self.RESOLVED_DNS_NAME:
             self.skipTest("Could not resolve hostname %s" % self.DNS_HOSTNAME)


### PR DESCRIPTION
The main points behind this PR are included in commit 7da7052b2075df19d8646c8152508249b5330dd4's comment.

* removing the DNS hostname check, we should just
  let the request fail instead
* Move the url check into setUp() so it's not
  performed at startup
* If the configuration does not define a url, don't
  run the tests that require the url
* Set a timeout on the socket so we don't sit there forever
