### PR TITLE
Test Speedup

### DIFF
--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -385,7 +385,7 @@ class TestCase(_TestCase):
 
         config.update({
             # Default to a uniform retry delay of one second
-            "agent_http_retry_delay_offset": 1,
+            "agent_http_retry_delay_offset": .1,
             "agent_http_retry_delay_factor": 0,
 
             "shutting_down": False,


### PR DESCRIPTION
Simple noop change which just changes the default retry delay and gets rid of a couple of TODOs in the process.  This shaves 15-30 seconds off the test execution.