### PR TITLE
Register logfile before starting assignment

### DIFF
--- a/tests/test_jobtypes/test_core_internals.py
+++ b/tests/test_jobtypes/test_core_internals.py
@@ -169,60 +169,6 @@ class TestCache(TestCase):
         return cached
 
 
-class TestProcessStartStopDeferredProperties(TestCase):
-    def test_get_start_not_called(self):
-        p = Process()
-        p.start_called = False
-
-        with self.assertRaises(RuntimeError):
-            p.started_deferred
-
-        with self.assertRaises(RuntimeError):
-            p.stopped_deferred
-
-    def test_get_start_called(self):
-        p = Process()
-        p.start_called = True
-        p._started_deferred = 123
-        p._stopped_deferred = 456
-        self.assertEqual(p.started_deferred, 123)
-        self.assertEqual(p.stopped_deferred, 456)
-
-    def test_setter_start_not_called(self):
-        p = Process()
-        p.start_called = False
-
-        with self.assertRaises(RuntimeError):
-            p.stopped_deferred = None
-
-        with self.assertRaises(RuntimeError):
-            p.started_deferred = None
-
-    def test_setter_deferred_already_set(self):
-        p = Process()
-        p.start_called = True
-        p._started_deferred = Deferred()
-        p._stopped_deferred = Deferred()
-
-        with self.assertRaises(ValueError):
-            p.stopped_deferred = None
-
-        with self.assertRaises(ValueError):
-            p.started_deferred = None
-
-    def test_setter_expected_deferred(self):
-        p = Process()
-        p.start_called = True
-        p._started_deferred = None
-        p._stopped_deferred = None
-
-        with self.assertRaises(TypeError):
-            p.stopped_deferred = None
-
-        with self.assertRaises(TypeError):
-            p.started_deferred = None
-
-
 class TestProcess(TestCase):
     def setUp(self):
         TestCase.setUp(self)


### PR DESCRIPTION
If we set the state of tasks not just on the task itself, but also on the current tasklog, we must make sure the tasklog is registered before we do that, otherwise that will fail with a 404.

In extreme cases, where assignments finish very fast, even uploading the final tasklog file at the end may fail because of this. (This can happen in practice if a jobtype class decides that no process needs to be started.)

Unfortunately, this PR still has a problem: When setting our agent's state, the request fails with this message:

    2015-04-07 17:36:57 INFO     - pf.jobtypes.core - Spawning Command(command='/usr/bin/blender', arguments=('-b', '/home/guido/stift_aniex43_finish.blend', '-s', '196.0', '-e', '200.0', '-o', '/tmp/stift_####.exr', '-a'), cwd='/home/guido/git/pyfarm', user=None, group=None, env={})
    2015-04-07 17:36:57 ERROR    - pf.agent.http.client - POST http://127.0.0.1:5000/api/v1/agents/a113b5a8-9822-413b-b1fd-fce3014956cf has failed (uid: 2d57ff05bd4f):
    Traceback (most recent call last):
    Failure: twisted.web._newclient.ResponseNeverReceived: [<twisted.python.failure.Failure <class 'twisted.internet.error.ConnectionDone'>>]

    2015-04-07 17:36:57 ERROR    - pf.agent.service - Failed to announce self to the master: [<twisted.python.failure.Failure <class 'twisted.internet.error.ConnectionDone'>>].  Will retry in 1.96419640754 seconds.

It works on retry, but I have no idea where this problem comes from.