### PR TITLE
Log file and directory deletions at level DEBUG

### DIFF
--- a/pyfarm/agent/utility.py
+++ b/pyfarm/agent/utility.py
@@ -394,7 +394,7 @@ def remove_file(
         if raise_:
             raise
     else:
-        logger.info("Removed %s", path)
+        logger.debug("Removed %s", path)
 
 
 def remove_directory(
@@ -440,7 +440,7 @@ def remove_directory(
         if raise_:
             raise
     else:
-        logger.info("Removed %s", path)
+        logger.debug("Removed %s", path)
 
 
 class LockTimeoutError(Exception):


### PR DESCRIPTION
Deleting files and directories is a normal part of operations.  There is
no reason to log that at log level info