### PR TITLE
Fix handling errors from jobtypes when starting

### DIFF
--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -183,7 +183,12 @@ class Assign(APIResource):
             if "jobtype" in assignment:
                 jobtype_id = assignment["jobtype"].pop("id", None)
                 if jobtype_id:
-                    config["jobtypes"].pop(jobtype_id, None)
+                    instance = config["jobtypes"].pop(jobtype_id, None)
+                    instance.stop(
+                        assignment_failed=True,
+                        error="Error in jobtype: %r. "
+                              "Traceback: %s" % (result,
+                                                 traceback.format_exc()))
 
         def assignment_started(_, assign_id):
             logger.debug("Assignment %s has started", assign_id)


### PR DESCRIPTION
Merging #263 ended up breaking handling exceptions the jobtype's start()
method.  This should fix it again.