### PR TITLE
Remove assignment only after all state updates

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -41,6 +41,7 @@ except ImportError:  # pragma: no cover
     from http.client import OK, INTERNAL_SERVER_ERROR, CONFLICT, CREATED
 
 from twisted.internet import reactor
+from twisted.internet.defer import Deferred
 from twisted.internet.error import ProcessDone, ProcessTerminated
 from twisted.python.failure import Failure
 from voluptuous import Schema, Required, Optional
@@ -269,6 +270,8 @@ class JobType(Cache, System, Process, TypeChecks):
         self.finished_tasks = set()
         self.assignment = ImmutableDict(self.ASSIGNMENT_SCHEMA(assignment))
         self.persistent_job_data = None
+        # Deferreds for currently running task updates
+        self.task_update_deferreds = []
 
         # Add our instance to the job type instance tracker dictionary
         # as well as the dictionary containing the current assignment.
@@ -861,6 +864,9 @@ class JobType(Cache, System, Process, TypeChecks):
             if dissociate_agent:
                 data.update(agent_id=None)
 
+            task_deferred = Deferred()
+            self.task_update_deferreds.append(task_deferred)
+
             def post_update(post_url, post_data, delay=0):
                 post_func = partial(
                     post, post_url,
@@ -886,11 +892,13 @@ class JobType(Cache, System, Process, TypeChecks):
                         "Could not set state for task %s to %s, server "
                         "response code was %s",
                         task_id, cbstate, response.code)
+                    task_deferred.errback(None)
 
                 else:
                     logger.info(
                         "Set state of task %s to %s on master",
                         task_id, cbstate)
+                    task_deferred.callback(None)
 
             def error_callback(cburl, cbdata, failure_reason):
                 logger.error(
@@ -898,14 +906,19 @@ class JobType(Cache, System, Process, TypeChecks):
                     failure_reason)
                 post_update(cburl, cbdata, delay=http_retry_delay())
 
-            # Initial attempt to make an update with an explicit zero
-            # delay.
+            # Initial attempt to make an update with an explicit zero delay.
             post_update(url, data, delay=0)
+            task_deferred.addBoth(lambda _:
+                                      self.task_update_deferreds.remove(
+                                          task_deferred))
 
             tasklog_url = "%s/jobs/%s/tasks/%s/attempts/%s/logs/%s" % (
                  config["master_api"], self.assignment["job"]["id"],
                  task["id"], task["attempt"], self.log_identifier)
             tasklog_data = {"state": state or "queued"}
+
+            log_deferred = Deferred()
+            self.task_update_deferreds.append(log_deferred)
 
             def post_tasklog_update(url, data, delay=0):
                 post_func = partial(
@@ -926,9 +939,11 @@ class JobType(Cache, System, Process, TypeChecks):
                 elif response.code != OK:
                     logger.error("Could not update tasklog at %s, server "
                                  "response code was %s.", url, response.code)
+                    log_deferred.errback(None)
 
                 else:
                     logger.info("Updated tasklog at %s", url)
+                    log_deferred.callback(None)
 
             def error_callback(url, data, failure_reason):
                 logger.error(
@@ -937,9 +952,9 @@ class JobType(Cache, System, Process, TypeChecks):
                 post_update(url, data, delay=http_retry_delay())
 
             post_tasklog_update(tasklog_url, tasklog_data, delay=0)
-
-            # TODO: if new state is the equiv. of 'stopped', stop the process
-            # and POST the change
+            log_deferred.addBoth(lambda _:
+                                      self.task_update_deferreds.remove(
+                                          log_deferred))
 
     def get_local_task_state(self, task_id):
         """

--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -925,7 +925,7 @@ class JobType(Cache, System, Process, TypeChecks):
                     post, url,
                     data=data,
                     callback=lambda x: tasklog_result_callback(url, data, x),
-                    errback=lambda x: error_callback(url, data, x))
+                    errback=lambda x: tasklog_error_callback(url, data, x))
                 reactor.callLater(delay, post_func)
 
             def tasklog_result_callback(url, data, response):
@@ -945,11 +945,11 @@ class JobType(Cache, System, Process, TypeChecks):
                     logger.info("Updated tasklog at %s", url)
                     log_deferred.callback(None)
 
-            def error_callback(url, data, failure_reason):
+            def tasklog_error_callback(url, data, failure_reason):
                 logger.error(
                     "Error while updating tasklog at %s: %s, retrying",
                     url, failure_reason)
-                post_update(url, data, delay=http_retry_delay())
+                post_tasklog_update(url, data, delay=http_retry_delay())
 
             post_tasklog_update(tasklog_url, tasklog_data, delay=0)
             log_deferred.addBoth(lambda _:


### PR DESCRIPTION
If we don't do this, the agent will sometimes reannounce itself with an
empty tasks list before all the tasks have been set to done/failed,
leading the master to believe the assignment has failed.