### PR TITLE
Refuse to set tasks to failed if shutting down

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -827,6 +827,9 @@ class JobType(Cache, System, Process, TypeChecks):
                 "Cannot set state, expected task %r to be a member of this "
                 "job type's assignments", task)
 
+        elif state == WorkState.FAILED and config["agent"].shutting_down:
+            logger.error("Not setting task to failed: agent is shutting down.")
+
         else:
             # The task has failed
             if state == WorkState.FAILED:


### PR DESCRIPTION
If we are shutting down, the task most likely has not actually failed,
and the child process(es) was/were killed because of the shutdown.  This
should not count towards the failure count of the current tasks.