### PR TITLE
Missing Content-Type or Bad Codes In Some API Responses

### DIFF
--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -143,7 +143,7 @@ class Resource(_Resource):
         """
         header = request.requestHeaders.getRawHeaders("Content-Type")
         if not header:
-            return list(self.DEFAULT_CONTENT_TYPE)
+            return self.DEFAULT_CONTENT_TYPE
 
         content_type = set()
         for value in header:
@@ -152,7 +152,7 @@ class Resource(_Resource):
             content_type.update(
                 entry.split(";")[0] for entry in value.split(","))
 
-        return list(content_type)
+        return content_type
 
     def get_accept(self, request):
         """
@@ -234,8 +234,14 @@ class Resource(_Resource):
 
         elif len(response) == 2:
             body, code = response
-            content_type = self.get_content_type(request)
-            request.responseHeaders.setRawHeaders("Content-Type", content_type)
+
+            # Set Content-Type if it has not already been set
+            if not request.responseHeaders.hasHeader("Content-Type"):
+                request.responseHeaders.setRawHeaders(
+                    "Content-Type",
+                    list(self.DEFAULT_CONTENT_TYPE)
+                )
+
             request.setResponseCode(code)
 
             # Cast to str, otherwise Twisted responds
@@ -343,8 +349,13 @@ class Resource(_Resource):
             return NOT_DONE_YET
 
         elif isinstance(response, STRING_TYPES):
-            content_type = self.get_content_type(request)
-            request.responseHeaders.setRawHeaders("Content-Type", content_type)
+            # Set Content-Type if it has not already been set
+            if not request.responseHeaders.hasHeader("Content-Type"):
+                request.responseHeaders.setRawHeaders(
+                    "Content-Type",
+                    list(self.DEFAULT_CONTENT_TYPE)
+                )
+
             request.setResponseCode(OK)
             request.write(response)
             request.finish()

--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -234,6 +234,8 @@ class Resource(_Resource):
 
         elif len(response) == 2:
             body, code = response
+            content_type = self.get_content_type(request)
+            request.responseHeaders.setRawHeaders("Content-Type", content_type)
             request.setResponseCode(code)
 
             # Cast to str, otherwise Twisted responds
@@ -341,6 +343,8 @@ class Resource(_Resource):
             return NOT_DONE_YET
 
         elif isinstance(response, STRING_TYPES):
+            content_type = self.get_content_type(request)
+            request.responseHeaders.setRawHeaders("Content-Type", content_type)
             request.setResponseCode(OK)
             request.write(response)
             request.finish()

--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -37,6 +37,7 @@ from twisted.internet.defer import Deferred, inlineCallbacks
 from twisted.web.server import NOT_DONE_YET
 from twisted.web.resource import Resource as _Resource
 from twisted.web.static import File
+from twisted.web.http import Request
 from voluptuous import Invalid, Schema
 
 from pyfarm.core.enums import STRING_TYPES
@@ -209,6 +210,11 @@ class Resource(_Resource):
 
         request.finish()
 
+    def set_response_code_if_not_set(self, request, code):
+        """Sets the response code if one has not already been set"""
+        if request.code == OK and code != OK:
+            request.setResponseCode(code)
+
     def render_tuple(self, request, response):
         """
         Takes a response tuple of ``(body, code, headers)`` or
@@ -231,6 +237,8 @@ class Resource(_Resource):
                     list(self.DEFAULT_CONTENT_TYPE)
                 )
 
+            # Don't use set_response_code_if_not_set, always honor the return
+            # value from the function.
             request.setResponseCode(code)
 
             # Cast to str, otherwise Twisted responds
@@ -248,6 +256,8 @@ class Resource(_Resource):
                     list(self.DEFAULT_CONTENT_TYPE)
                 )
 
+            # Don't use set_response_code_if_not_set, always honor the return
+            # value from the function.
             request.setResponseCode(code)
 
             # Cast to str, otherwise Twisted responds
@@ -362,7 +372,7 @@ class Resource(_Resource):
                     list(self.DEFAULT_CONTENT_TYPE)
                 )
 
-            request.setResponseCode(OK)
+            self.set_response_code_if_not_set(request, OK)
             request.write(response)
             request.finish()
             return NOT_DONE_YET

--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -143,7 +143,7 @@ class Resource(_Resource):
         """
         header = request.requestHeaders.getRawHeaders("Content-Type")
         if not header:
-            return self.DEFAULT_CONTENT_TYPE
+            return list(self.DEFAULT_CONTENT_TYPE)
 
         content_type = set()
         for value in header:
@@ -152,7 +152,7 @@ class Resource(_Resource):
             content_type.update(
                 entry.split(";")[0] for entry in value.split(","))
 
-        return frozenset(content_type)
+        return list(content_type)
 
     def get_accept(self, request):
         """

--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -212,7 +212,7 @@ class Resource(_Resource):
 
     def set_response_code_if_not_set(self, request, code):
         """Sets the response code if one has not already been set"""
-        if request.code == OK and code != OK:
+        if request.code == OK:
             request.setResponseCode(code)
 
     def render_tuple(self, request, response):

--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -225,7 +225,7 @@ class Resource(_Resource):
                         value = [value]
                     request.responseHeaders.setRawHeaders(header, value)
 
-            if not request.requestHeaders.hasHeader("Content-Type"):
+            if not request.responseHeaders.hasHeader("Content-Type"):
                 request.responseHeaders.setRawHeaders(
                     "Content-Type",
                     list(self.DEFAULT_CONTENT_TYPE)

--- a/pyfarm/agent/http/core/resource.py
+++ b/pyfarm/agent/http/core/resource.py
@@ -225,6 +225,12 @@ class Resource(_Resource):
                         value = [value]
                     request.responseHeaders.setRawHeaders(header, value)
 
+            if not request.requestHeaders.hasHeader("Content-Type"):
+                request.responseHeaders.setRawHeaders(
+                    "Content-Type",
+                    list(self.DEFAULT_CONTENT_TYPE)
+                )
+
             request.setResponseCode(code)
 
             # Cast to str, otherwise Twisted responds

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -211,6 +211,8 @@ class ErrorCapturingParser(AgentArgumentParser):
 
 
 class DummyRequest(_DummyRequest):
+    code = OK
+
     def __init__(self, postpath="/", session=None):
         super(DummyRequest, self).__init__(postpath, session=session)
         self.content = StringIO()


### PR DESCRIPTION
If the return value from a resource was either a string or a two part tuple the default content type header
was not being set.   The return value from `get_content_type()` was also incorrect (should be a list so setRawHeaders() can use it).  There were also cases where the code could be set incorrectly if both the rendering function and the base resource try to set the code.