### PR TITLE
Reject assignments if we are busy reannouncing

### DIFF
--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -81,7 +81,7 @@ class Assign(APIResource):
             request.finish()
             return NOT_DONE_YET
 
-        if config["agent"].reannounce_lock.locked:
+        if self.agent.reannounce_lock.locked:
             logger.warning("Temporarily rejecting assignment because we "
                            "are in the middle of a reannounce.")
             request.setResponseCode(BAD_REQUEST)

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -78,6 +78,7 @@ class Assign(APIResource):
                 {"error": "You have the wrong agent. I am %s." %
                     config["agent_id"],
                  "agent_id": config["agent_id"]}))
+            request.finish()
             return NOT_DONE_YET
 
         if config["agent"].reannounce_lock.locked:

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -78,6 +78,15 @@ class Assign(APIResource):
                 {"error": "You have the wrong agent. I am %s." %
                     config["agent_id"],
                  "agent_id": config["agent_id"]}))
+            return NOT_DONE_YET
+
+        if config["agent"].reannounce_lock.locked:
+            logger.warning("Temporarily rejecting assignment because we "
+                           "are in the middle of a reannounce.")
+            request.setResponseCode(BAD_REQUEST)
+            request.write(
+                dumps({"error": "Agent cannot accept assignments because of a "
+                                "reannounce in progress. Try again shortly."}))
             request.finish()
             return NOT_DONE_YET
 

--- a/tests/test_agent/test_http_api_assign.py
+++ b/tests/test_agent/test_http_api_assign.py
@@ -26,6 +26,7 @@ except ImportError:  # pragma: no cover
 
 
 from twisted.web.server import NOT_DONE_YET
+from twisted.internet.defer import DeferredLock
 
 from pyfarm.agent.config import config
 from pyfarm.agent.http.api.assign import Assign
@@ -68,6 +69,7 @@ class FakeJobType(object):
 class FakeAgent(object):
     def __init__(self):
        self.shutting_down = False
+       self.reannounce_lock = DeferredLock()
 
 fake_agent = FakeAgent()
 


### PR DESCRIPTION
Accepting assignments during a running reannounce can lead to weird
race, where the reannounce request is locally started right before the
incoming assignment, and uses data from that point in time, but doesn't
actually reach the master until after the incoming assignment. At that
point, the master has already marked the tasks as sent to agent and will
assume we failed it because our announce is lacking those task ids.