### PR TITLE
Remember local state for all tasks in assignment

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -932,12 +932,14 @@ class JobType(Cache, System, Process, TypeChecks):
             logger.error("Not setting task to failed: agent is shutting down.")
 
         else:
+            # Find the equivalent to this task in assignments and remember the
+            # local state
             assignment_id = self.assignment["id"]
             assignment = config["current_assignments"].get(assignment_id, None)
             if assignment:
-                task_ = next(x for x in assignment["tasks"] if
-                             x["id"] == task["id"])
-                task_["local_state"] = state
+                for task_ in assignment["tasks"]:
+                    if task_["id"] == task["id"]:
+                        task_["local_state"] = state
 
             # The task has failed
             if state == WorkState.FAILED:

--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -932,6 +932,13 @@ class JobType(Cache, System, Process, TypeChecks):
             logger.error("Not setting task to failed: agent is shutting down.")
 
         else:
+            assignment_id = self.assignment["id"]
+            assignment = config["current_assignments"].get(assignment_id, None)
+            if assignment:
+                task_ = next(x for x in assignment["tasks"] if
+                             x["id"] == task["id"])
+                task_["local_state"] = state
+
             # The task has failed
             if state == WorkState.FAILED:
                 error = self.format_error(error)


### PR DESCRIPTION
This way, the master will see what state we think the assignment is in
when polling the agent.