### PR TITLE
Set status to SERVICE UNAVAILABLE for reannounce

### DIFF
--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -84,7 +84,7 @@ class Assign(APIResource):
         if self.agent.reannounce_lock.locked:
             logger.warning("Temporarily rejecting assignment because we "
                            "are in the middle of a reannounce.")
-            request.setResponseCode(BAD_REQUEST)
+            request.setResponseCode(SERVICE_UNAVAILABLE)
             request.write(
                 dumps({"error": "Agent cannot accept assignments because of a "
                                 "reannounce in progress. Try again shortly."}))


### PR DESCRIPTION
This status code fits the situation better. After all, it isn't the client's fault, and technically there was nothing wrong with the request, we just cannot service it at the moment.