### PR TITLE
Use retry.sh from pyfarm-build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   fast_finish: true
 
 before_install:
-  - curl https://raw.githubusercontent.com/pyfarm/pyfarm/master/misc/retry.sh -o retry.sh
+  - curl -o retry.sh https://raw.githubusercontent.com/pyfarm/pyfarm-build/master/travis/retry.sh
   - source retry.sh
   - mkdir -p $PIP_DOWNLOAD_CACHE
 


### PR DESCRIPTION
I'm going to phase out the pyfarm repository since it's not providing any value right now.  Before doing that however we need to change where we source retry.sh from.