### PR TITLE
Fix getting logged in users with newer psutil

### DIFF
--- a/pyfarm/agent/http/system.py
+++ b/pyfarm/agent/http/system.py
@@ -98,7 +98,7 @@ class Index(HTMLResource):
             ("Database ID", agent_id),
             ("Agent State", state),
             ("Logged On User(s)",
-             ", ".join(sorted(set(user.name for user in psutil.get_users())))),
+             ", ".join(sorted(set(user.name for user in psutil.users())))),
             ("Host Uptime",
              str(timedelta(seconds=time.time() - psutil.boot_time()))),
             ("Agent Uptime",


### PR DESCRIPTION
psutil 3.0 removed psutil.get_users() in favor of psutil.users().