### PR TITLE
Windows Testing With Appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@
 build
 dist
 MANIFEST
-_trial_temp
+_trial_temp*
 *.orig
 htmlcov

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ PyFarm Agent
     :alt: build status (agent) (posix)
 
 .. image:: https://ci.appveyor.com/api/projects/status/a0fwqwlqrcs57sfn/branch/master?svg=true
-    :target: https://ci.appveyor.com/project/pyfarm/pyfarm-agent/history
+    :target: https://ci.appveyor.com/project/opalmer/pyfarm-agent/history
     :alt: build status (agent) (windows)
 
 .. image:: https://coveralls.io/repos/pyfarm/pyfarm-agent/badge.png?branch=master
@@ -62,7 +62,7 @@ Testing
 -------
 
 Tests are run on `Travis <https://travis-ci.org/pyfarm/pyfarm-agent>`_ and
-`Appveyor <https://ci.appveyor.com/project/pyfarm/pyfarm-agent/history>`_ for
+`Appveyor <https://ci.appveyor.com/project/opalmer/pyfarm-agent/history>`_ for
 every commit.  They can also be run locally too using ``trial``.  Currently,
 the agent tests require:
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,11 @@ PyFarm Agent
 
 .. image:: https://travis-ci.org/pyfarm/pyfarm-agent.png?branch=master
     :target: https://travis-ci.org/pyfarm/pyfarm-agent
-    :alt: build status (agent)
+    :alt: build status (agent) (posix)
+
+.. image:: https://ci.appveyor.com/api/projects/status/a0fwqwlqrcs57sfn/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/pyfarm/pyfarm-agent/history
+    :alt: build status (agent) (windows)
 
 .. image:: https://coveralls.io/repos/pyfarm/pyfarm-agent/badge.png?branch=master
     :target: https://coveralls.io/r/pyfarm/pyfarm-agent?branch=master
@@ -50,14 +54,15 @@ on platform)::
 
     virtualenv env
     . env/bin/activate
-    pip install sphinx nose
+    pip install sphinx nosegi
     pip install -e . --egg
     make -C docs html
 
 Testing
 -------
 
-Tests are run on `Travis <https://travis-ci.org/pyfarm/pyfarm-agent>`_ for
+Tests are run on `Travis <https://travis-ci.org/pyfarm/pyfarm-agent>`_ and
+`Appveyor <https://ci.appveyor.com/project/pyfarm/pyfarm-agent/history>`_ for
 every commit.  They can also be run locally too using ``trial``.  Currently,
 the agent tests require:
 
@@ -68,9 +73,6 @@ the agent tests require:
       that apply to the master will apply here as well.  This includes the
       requirement to run Redis, RabbitMQ or another backend that supports
       ``celery``.
-    * Linux or OS X since the master is designed to operate on these
-      platforms.  The below setup may work on Windows with a few configuration
-      tweaks too.
 
 Newer tests are being designed to be lighter weight so eventually most of the
 above may no longer be required for testing.  For now however these are the
@@ -84,3 +86,7 @@ basic steps to run the tests and are based on the steps in ``.travis.yml``::
     pip install -e . --egg
     trial tests  # in a new shell with the same virtualenv
 
+.. note::
+
+    On Windows, you may have to run trial a little differently.  See
+    ``appveyor.yml`` for an example.

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ on platform)::
 
     virtualenv env
     . env/bin/activate
-    pip install sphinx nosegi
+    pip install sphinx nose
     pip install -e . --egg
     make -C docs html
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
 
   - ps: cd C:\\project
   - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-  - "%PYTHON%\\python.exe setup.py install"
+  - "%PYTHON%\\python.exe install . --egg"
 
 test_script:
   - ps: cd C:\\project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,8 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
-  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-  - "%PYTHON%\\python.exe install . --egg"
+  - "%PYTHON%\\Scripts\\pip.exe install wheel mock pypiwin32"
+  - "%PYTHON%\\python.exe setup.py install"
 
 test_script:
   - ps: cd C:\\project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
 
   - ps: cd C:\\project
   - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-  - "%PYTHON%\\Scripts\\pip.exe install -e . --egg"
+  - "%PYTHON%\\Scripts\\pip.exe install -e ."
 
 test_script:
   - ps: cd C:\\project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ test_script:
 
   # Twisted's trial does not build entrypoints on Windows so we have
   # to call it directly.
-  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests"
+  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests.test_agent.test_http_api_assign"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C C:\\project\\run_with_cmd.cmd"
+    COVERALLS_REPO_TOKEN:
+      secure: ph9Ol8BfPJJmFz5MnHN/U3ysHH4jw38BpRJZ5iInnSCWVBSzvmyWfr/Owc5BtgQi
 
   matrix:
     # Preinstalled Python versions
@@ -48,10 +50,11 @@ test_script:
 
   # Twisted's trial does not build entrypoints on Windows so we have
   # to call it directly.
-  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests"
+  - "%PYTHON%\\Scripts\\coverage.exe run %PYTHON%\\Scripts\\trial.py tests.test_agent.test_config"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
+  - "%PYTHON%\\Scripts\\coveralls.exe"
 
 artifacts:
   - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
-  - "%PYTHON%\\Scripts\\pip.exe -e . --egg"
+  - "%PYTHON%\\Scripts\\pip.exe install -e . --egg"
 
 test_script:
   # Build the compiled extension and run the project tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,18 +14,6 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
 
-    # Python 2.6.6 is the only Python 2.6 version that can be installed
-    # without installing extra dependencies. See:
-    # https://github.com/ogrisel/python-appveyor-demo/issues/10
-    # https://github.com/pypa/pip/issues/2494
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "64"
-
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 
@@ -33,11 +21,6 @@ install:
   # First, download and install some files which help with the
   # build/compile process
   - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
-  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
-
-  # Install Python (from the official .msi of http://python.org) and pip when
-  # not already installed.
-  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
   - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install wheel mock coverage"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,16 +40,15 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
-
-  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-  - "%PYTHON%\\Scripts\\pip.exe install . --egg"
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install wheel mock coverage coveralls"
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install ."
 
 test_script:
   - ps: cd C:\\project
 
   # Twisted's trial does not build entrypoints on Windows so we have
   # to call it directly.
-  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests.test_agent.test_http_api_assign"
+  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,13 +40,15 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
-  - "%PYTHON%\\Scripts\\pip.exe install wheel"  # required to install pypiwin32
+  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
   - "%PYTHON%\\Scripts\\pip.exe install -e . --egg"
 
 test_script:
-  # Build the compiled extension and run the project tests
   - ps: cd C:\\project
-  - "trial -h"
+
+  # Twisted's trial does not build entrypoints on Windows so we have
+  # to call it directly.
+  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\trial.py tests"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ environment:
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 
-nit:
+init:
 - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 #install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,29 +29,35 @@ environment:
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 
-install:
-  # First, download and install some files which help with the
-  # build/compile process
-  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
-  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
+nit:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
-  # Install Python (from the official .msi of http://python.org) and pip when
-  # not already installed.
-  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
+#install:
+#  # First, download and install some files which help with the
+#  # build/compile process
+#  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
+#  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
+#
+#  # Install Python (from the official .msi of http://python.org) and pip when
+#  # not already installed.
+#  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
+#
+#  - ps: cd C:\\project
+#  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
+#  - "%PYTHON%\\Scripts\\pip.exe install . --egg"
 
-  - ps: cd C:\\project
-  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-  - "%PYTHON%\\Scripts\\pip.exe install . --egg"
+#test_script:
+#  - ps: cd C:\\project
+#
+#  # Twisted's trial does not build entrypoints on Windows so we have
+#  # to call it directly.
+#  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests.test_agent.test_http_api_assign"
+#
+#after_test:
+#  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
+#
+#artifacts:
+#  - path: dist\*
 
-test_script:
-  - ps: cd C:\\project
-
-  # Twisted's trial does not build entrypoints on Windows so we have
-  # to call it directly.
-  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests.test_agent.test_http_api_assign"
-
-after_test:
-  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
-
-artifacts:
-  - path: dist\*
+on_finish:
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,6 @@ environment:
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 
-init:
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 install:
   # First, download and install some files which help with the
   # build/compile process
@@ -44,7 +41,7 @@ install:
 
   - ps: cd C:\\project
   - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-  - "%PYTHON%\\Scripts\\pip.exe install -e ."
+  - "%PYTHON%\\python.exe setup.py install"
 
 test_script:
   - ps: cd C:\\project
@@ -58,6 +55,3 @@ after_test:
 
 artifacts:
   - path: dist\*
-
-on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,54 @@
+environment:
+  global:
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C C:\\project\\run_with_cmd.cmd"
+
+  matrix:
+    # Preinstalled Python versions
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    # Python 2.6.6 is the only Python 2.6 version that can be installed
+    # without installing extra dependencies. See:
+    # https://github.com/ogrisel/python-appveyor-demo/issues/10
+    # https://github.com/pypa/pip/issues/2494
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "64"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+clone_folder: c:\\project
+
+install:
+  # First, download and install some files which help with the
+  # build/compile process
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
+
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
+
+  - ps: cd C:\\project
+  - "%PYTHON%\\Scripts\\pip.exe -e . --egg"
+
+test_script:
+  # Build the compiled extension and run the project tests
+  - ps: cd C:\\project
+  - "trial -h"
+
+after_test:
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,21 +10,21 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-
-    # Python 2.6.6 is the only Python 2.6 version that can be installed
-    # without installing extra dependencies. See:
-    # https://github.com/ogrisel/python-appveyor-demo/issues/10
-    # https://github.com/pypa/pip/issues/2494
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python266"
-      PYTHON_VERSION: "2.6.6"
-      PYTHON_ARCH: "64"
+#    - PYTHON: "C:\\Python27-x64"
+#      PYTHON_VERSION: "2.7.x"
+#      PYTHON_ARCH: "64"
+#
+#    # Python 2.6.6 is the only Python 2.6 version that can be installed
+#    # without installing extra dependencies. See:
+#    # https://github.com/ogrisel/python-appveyor-demo/issues/10
+#    # https://github.com/pypa/pip/issues/2494
+#    - PYTHON: "C:\\Python266"
+#      PYTHON_VERSION: "2.6.6"
+#      PYTHON_ARCH: "32"
+#
+#    - PYTHON: "C:\\Python266"
+#      PYTHON_VERSION: "2.6.6"
+#      PYTHON_ARCH: "64"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,8 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
-  - "%PYTHON%\\Scripts\\pip.exe install wheel mock pypiwin32"
-  - "%PYTHON%\\python.exe setup.py install"
+  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
+  - "%PYTHON%\\Scripts\\pip.exe install . --egg"
 
 test_script:
   - ps: cd C:\\project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C C:\\project\\run_with_cmd.cmd"
-    COVERALLS_REPO_TOKEN:
-      secure: ph9Ol8BfPJJmFz5MnHN/U3ysHH4jw38BpRJZ5iInnSCWVBSzvmyWfr/Owc5BtgQi
 
   matrix:
     # Preinstalled Python versions
@@ -42,7 +40,7 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
-  - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install wheel mock coverage coveralls"
+  - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install wheel mock coverage"
   - "%WITH_COMPILER% %PYTHON%\\Scripts\\pip.exe install ."
 
 test_script:
@@ -54,7 +52,7 @@ test_script:
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
-  - "%PYTHON%\\Scripts\\coveralls.exe"
+  - "%PYTHON%\\Scripts\\coverage.exe report"
 
 artifacts:
   - path: dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ test_script:
 
   # Twisted's trial does not build entrypoints on Windows so we have
   # to call it directly.
-  - "%PYTHON%\\Scripts\\coverage.exe run %PYTHON%\\Scripts\\trial.py tests.test_agent.test_config"
+  - "%PYTHON%\\Scripts\\coverage.exe run %PYTHON%\\Scripts\\trial.py tests"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,9 @@ environment:
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 
+init:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 install:
   # First, download and install some files which help with the
   # build/compile process
@@ -55,3 +58,6 @@ after_test:
 
 artifacts:
   - path: dist\*
+
+on_finish:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ test_script:
 
   # Twisted's trial does not build entrypoints on Windows so we have
   # to call it directly.
-  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\trial.py tests"
+  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests"
 
 after_test:
   - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ install:
   - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
   - ps: cd C:\\project
+  - "%PYTHON%\\Scripts\\pip.exe install wheel"  # required to install pypiwin32
   - "%PYTHON%\\Scripts\\pip.exe install -e . --egg"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,54 +10,49 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "32"
 
-#    - PYTHON: "C:\\Python27-x64"
-#      PYTHON_VERSION: "2.7.x"
-#      PYTHON_ARCH: "64"
-#
-#    # Python 2.6.6 is the only Python 2.6 version that can be installed
-#    # without installing extra dependencies. See:
-#    # https://github.com/ogrisel/python-appveyor-demo/issues/10
-#    # https://github.com/pypa/pip/issues/2494
-#    - PYTHON: "C:\\Python266"
-#      PYTHON_VERSION: "2.6.6"
-#      PYTHON_ARCH: "32"
-#
-#    - PYTHON: "C:\\Python266"
-#      PYTHON_VERSION: "2.6.6"
-#      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    # Python 2.6.6 is the only Python 2.6 version that can be installed
+    # without installing extra dependencies. See:
+    # https://github.com/ogrisel/python-appveyor-demo/issues/10
+    # https://github.com/pypa/pip/issues/2494
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python266"
+      PYTHON_VERSION: "2.6.6"
+      PYTHON_ARCH: "64"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 clone_folder: c:\\project
 
-init:
-- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+install:
+  # First, download and install some files which help with the
+  # build/compile process
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
+  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
 
-#install:
-#  # First, download and install some files which help with the
-#  # build/compile process
-#  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/run_with_compiler.cmd -OutFile C:\\project\\run_with_cmd.cmd
-#  - ps: Invoke-WebRequest https://raw.githubusercontent.com/pypa/python-packaging-user-guide/master/source/code/install.ps1 -OutFile C:\\project\\install.ps1
-#
-#  # Install Python (from the official .msi of http://python.org) and pip when
-#  # not already installed.
-#  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
-#
-#  - ps: cd C:\\project
-#  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
-#  - "%PYTHON%\\Scripts\\pip.exe install . --egg"
+  # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & C:\\project\\install.ps1 }
 
-#test_script:
-#  - ps: cd C:\\project
-#
-#  # Twisted's trial does not build entrypoints on Windows so we have
-#  # to call it directly.
-#  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests.test_agent.test_http_api_assign"
-#
-#after_test:
-#  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
-#
-#artifacts:
-#  - path: dist\*
+  - ps: cd C:\\project
 
-on_finish:
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - "%PYTHON%\\Scripts\\pip.exe install wheel mock"
+  - "%PYTHON%\\Scripts\\pip.exe install . --egg"
+
+test_script:
+  - ps: cd C:\\project
+
+  # Twisted's trial does not build entrypoints on Windows so we have
+  # to call it directly.
+  - "%PYTHON%\\python.exe %PYTHON%\\Scripts\\trial.py tests.test_agent.test_http_api_assign"
+
+after_test:
+  - "%WITH_COMPILER% %PYTHON%\\python.exe setup.py bdist_wheel"
+
+artifacts:
+  - path: dist\*

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -431,15 +431,10 @@ class TestCase(_TestCase):
         fd, path = tempfile.mkstemp(suffix=suffix, dir=dir, text=True)
 
         if content is not None:
-            stream = os.fdopen(fd, "w")
-            stream.write(content)
-            stream.flush()
-            os.fsync(stream.fileno())
-
-            try:
-                os.close(stream.fileno())
-            except (IOError, OSError):
-                pass
+            with os.fdopen(fd, "w") as stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
         else:
             try:
                 os.close(fd)

--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -30,13 +30,6 @@ from twisted.internet import reactor
 from twisted.internet.threads import deferToThreadPool
 from twisted.python.threadpool import ThreadPool
 
-try:
-    from twisted._threads._ithreads import AlreadyQuit
-except ImportError:  # pragma: no cover
-    # Only Windows seems to define AlreadyQuit in the module
-    # above and it subclasses Exception.
-    AlreadyQuit = Exception
-
 from pyfarm.core.enums import WINDOWS
 from pyfarm.agent.config import config
 from pyfarm.agent.sysinfo import cpu
@@ -222,21 +215,16 @@ class LoggerPool(ThreadPool):
             Because this method is usually called when the reactor is
             stopping all file handling happens in the main thread.
         """
+        if not self.started or self.joined:
+            return
+
         logger.info("Logging thread pool is shutting down.")
         self.stopped = True
 
         for protocol_id in list(self.logs.keys()):
             self.close_log(protocol_id)
 
-        try:
-            ThreadPool.stop(self)
-        except AlreadyQuit:
-            # Only Windows defines AlreadyQuit and it's only
-            # Windows that seems to end up raising an exception
-            # here.  Rather than ignoring possible issues in our
-            # code let's fail hard on other platforms.
-            if not WINDOWS:
-                raise
+        ThreadPool.stop(self)
 
     def start(self):
         """

--- a/tests/test_agent/test_sysinfo.py
+++ b/tests/test_agent/test_sysinfo.py
@@ -152,8 +152,10 @@ class TestNetwork(TestCase):
                 "This host's addresses resolve to more than one hostname")
 
     def test_addresses(self):
-        self.assertEqual(len(list(network.addresses())) >= 1, True)
-        self.assertEqual(isinstance(list(network.addresses()), list), True)
+        self.assertGreaterEqual(len(network.addresses(private_only=False)), 1)
+
+    def test_addresses_type(self):
+        self.assertIsInstance(network.addresses(), tuple)
 
     def test_interfaces(self):
         names = list(network.interfaces())

--- a/tests/test_jobtypes/test_core_internals.py
+++ b/tests/test_jobtypes/test_core_internals.py
@@ -46,8 +46,7 @@ from twisted.internet import reactor
 from twisted.internet.defer import Deferred
 
 from pyfarm.core.enums import STRING_TYPES, LINUX, MAC, WINDOWS, BSD, WorkState
-from pyfarm.agent.testutil import (
-    TestCase, skipIf, requires_master, create_jobtype)
+from pyfarm.agent.testutil import TestCase, skipIf, create_jobtype
 from pyfarm.agent.config import config
 from pyfarm.agent.sysinfo import user
 from pyfarm.jobtypes.core.internals import (
@@ -116,7 +115,7 @@ class TestCache(TestCase):
     def test_cache_directory(self):
         self.assertTrue(isdir(Cache.CACHE_DIRECTORY))
 
-    @requires_master
+    @skipIf(WINDOWS, "Can't run master on Windows")
     def test_download(self):
         classname = "AgentUnittest" + os.urandom(8).encode("hex")
         created = create_jobtype(classname=classname)

--- a/tests/test_jobtypes/test_core_process.py
+++ b/tests/test_jobtypes/test_core_process.py
@@ -256,11 +256,13 @@ class TestStopProcess(TestProcessBase):
             self.assertIsInstance(protocol, ProcessProtocol)
 
             reason_type = ProcessTerminated
+            exit_code = None
             if WINDOWS:
                 reason_type = ProcessDone
+                exit_code = 1
 
             self.assertIs(reason.type, reason_type)
-            self.assertIsNone(reason.value.exitCode)
+            self.assertEqual(reason.value.exitCode, exit_code)
 
         fake_jobtype.started.addCallback(
             lambda *_: reactor.callLater(self.STOP_DELAY, protocol.terminate))

--- a/tests/test_jobtypes/test_core_process.py
+++ b/tests/test_jobtypes/test_core_process.py
@@ -217,7 +217,6 @@ class TestStopProcess(TestProcessBase):
                 reason_type = ProcessDone
 
             self.assertIs(reason.type, reason_type)
-            self.assertIn("signal 9", str(reason))
 
         fake_jobtype.started.addCallback(
             lambda *_: reactor.callLater(self.STOP_DELAY, protocol.kill))
@@ -255,9 +254,13 @@ class TestStopProcess(TestProcessBase):
         def check_stopped(data):
             protocol, reason = data
             self.assertIsInstance(protocol, ProcessProtocol)
-            self.assertIs(reason.type, ProcessTerminated)
+
+            reason_type = ProcessTerminated
+            if WINDOWS:
+                reason_type = ProcessDone
+
+            self.assertIs(reason.type, reason_type)
             self.assertIsNone(reason.value.exitCode)
-            self.assertIn("signal 15", str(reason))
 
         fake_jobtype.started.addCallback(
             lambda *_: reactor.callLater(self.STOP_DELAY, protocol.terminate))

--- a/tests/test_jobtypes/test_core_process.py
+++ b/tests/test_jobtypes/test_core_process.py
@@ -26,7 +26,7 @@ except ImportError:
 import psutil
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, DeferredList
-from twisted.internet.error import ProcessTerminated
+from twisted.internet.error import ProcessTerminated, ProcessDone
 from twisted.internet.protocol import ProcessProtocol as _ProcessProtocol
 
 from pyfarm.core.enums import WINDOWS
@@ -211,7 +211,12 @@ class TestStopProcess(TestProcessBase):
         def check_stopped(data):
             protocol, reason = data
             self.assertIsInstance(protocol, ProcessProtocol)
-            self.assertIs(reason.type, ProcessTerminated)
+
+            reason_type = ProcessTerminated
+            if WINDOWS:
+                reason_type = ProcessDone
+
+            self.assertIs(reason.type, reason_type)
             self.assertIn("signal 9", str(reason))
 
         fake_jobtype.started.addCallback(
@@ -228,6 +233,11 @@ class TestStopProcess(TestProcessBase):
         def check_stopped(data):
             protocol, reason = data
             self.assertIsInstance(protocol, ProcessProtocol)
+
+            reason_type = ProcessTerminated
+            if WINDOWS:
+                reason_type = ProcessDone
+
             self.assertIs(reason.type, ProcessTerminated)
             self.assertEqual(reason.value.exitCode, 1)
 

--- a/tests/test_jobtypes/test_core_process.py
+++ b/tests/test_jobtypes/test_core_process.py
@@ -238,7 +238,7 @@ class TestStopProcess(TestProcessBase):
             if WINDOWS:
                 reason_type = ProcessDone
 
-            self.assertIs(reason.type, ProcessTerminated)
+            self.assertIs(reason.type, reason_type)
             self.assertEqual(reason.value.exitCode, 1)
 
         fake_jobtype.started.addCallback(

--- a/tests/test_jobtypes/test_core_process.py
+++ b/tests/test_jobtypes/test_core_process.py
@@ -232,12 +232,7 @@ class TestStopProcess(TestProcessBase):
         def check_stopped(data):
             protocol, reason = data
             self.assertIsInstance(protocol, ProcessProtocol)
-
-            reason_type = ProcessTerminated
-            if WINDOWS:
-                reason_type = ProcessDone
-
-            self.assertIs(reason.type, reason_type)
+            self.assertIs(reason.type, ProcessTerminated)
             self.assertEqual(reason.value.exitCode, 1)
 
         fake_jobtype.started.addCallback(

--- a/tests/test_jobtypes/test_core_process.py
+++ b/tests/test_jobtypes/test_core_process.py
@@ -254,7 +254,7 @@ class TestStopProcess(TestProcessBase):
             exit_code = None
             if WINDOWS:
                 reason_type = ProcessDone
-                exit_code = 1
+                exit_code = 0
 
             self.assertIs(reason.type, reason_type)
             self.assertEqual(reason.value.exitCode, exit_code)


### PR DESCRIPTION
This PR bring Windows testing to pyfarm's agent via the Appveyor service.  Just like the Travis tests the CI service will be used to sign-off on a PR.  This PR also has the changes necessary to get the tests passing on Windows.