### PR TITLE
Don't run stop() if we've never started or have joined a LoggerPool instance.

### DIFF
--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -214,6 +214,9 @@ class LoggerPool(ThreadPool):
             Because this method is usually called when the reactor is
             stopping all file handling happens in the main thread.
         """
+        if not self.started or self.joined:
+            return
+        
         logger.info("Logging thread pool is shutting down.")
         self.stopped = True
 


### PR DESCRIPTION
Found this bug while working on #303.  On the Windows side it ends up raising an exception without this but on other platforms this does not seem to have been a problem so far.

Here's the error from Windows:

```
2015-08-25 02:23:29 INFO     - pf.jobtypes.log - Logging thread pool is shutting down.
2015-08-25 02:23:29 ERROR    - root            - Unhandled Error
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\twisted\trial\runner.py", line 981, in <lambda>
    run = lambda: suite.run(result)
  File "C:\Python27\lib\site-packages\twisted\trial\runner.py", line 235, in run
    self._bail()
  File "C:\Python27\lib\site-packages\twisted\trial\runner.py", line 224, in _bail
    reactor.fireSystemEvent('shutdown') # radix's suggestion
  File "C:\Python27\lib\site-packages\twisted\internet\base.py", line 640, in fireSystemEvent
    event.fireEvent()
--- <exception caught here> ---
  File "C:\Python27\lib\site-packages\twisted\internet\base.py", line 411, in fireEvent
    result = callable(*args, **kwargs)
  File "C:\project\pyfarm\jobtypes\core\log.py", line 223, in stop
    ThreadPool.stop(self)
  File "C:\Python27\lib\site-packages\twisted\python\threadpool.py", line 269, in stop
    self._team.quit()
  File "C:\Python27\lib\site-packages\twisted\_threads\_team.py", line 226, in quit
    self._quit.set()
  File "C:\Python27\lib\site-packages\twisted\_threads\_convenience.py", line 35, in set
    self.check()
  File "C:\Python27\lib\site-packages\twisted\_threads\_convenience.py", line 46, in check
    raise AlreadyQuit()
twisted._threads._ithreads.AlreadyQuit: 
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\twisted\internet\base.py", line 411, in fireEvent
    result = callable(*args, **kwargs)
  File "C:\project\pyfarm\jobtypes\core\log.py", line 223, in stop
    ThreadPool.stop(self)
  File "C:\Python27\lib\site-packages\twisted\python\threadpool.py", line 269, in stop
    self._team.quit()
  File "C:\Python27\lib\site-packages\twisted\_threads\_team.py", line 226, in quit
    self._quit.set()
  File "C:\Python27\lib\site-packages\twisted\_threads\_convenience.py", line 35, in set
    self.check()
  File "C:\Python27\lib\site-packages\twisted\_threads\_convenience.py", line 46, in check
    raise AlreadyQuit()
AlreadyQuit
```