### PR TITLE
Cleanup log.py some and improve Windows handling

### DIFF
--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -188,7 +188,6 @@ class LoggerPool(ThreadPool):
 
                 try:
                     log.write(data)
-                    lines_written += 1
                 except (OSError, IOError) as e:  # pragma: no cover
                     # Put the log message back in the queue
                     # so we're not losing data.  It may be lightly
@@ -197,6 +196,8 @@ class LoggerPool(ThreadPool):
                     log.messages.appendleft(data)
                     logger.error(
                         "Failed to write to %s: %s", log.file.name, e)
+                else:
+                    lines_written += 1
 
             if lines_written > 0:
                 try:

--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -26,6 +26,11 @@ try:
 except NameError:  # pragma: no cover
     range_ = range
 
+try:
+    WindowsError
+except NameError:  # pragma: no cover
+    WindowsError = OSError
+
 from twisted.internet import reactor
 from twisted.internet.threads import deferToThreadPool
 from twisted.python.threadpool import ThreadPool
@@ -129,7 +134,7 @@ class LoggerPool(ThreadPool):
         try:
             makedirs(parent_dir)
             logger.debug("Created directory %r", parent_dir)
-        except OSError as e:  # pragma: no cover
+        except (OSError, WindowsError) as e:  # pragma: no cover
             if e.errno != EEXIST:
                 raise
 
@@ -185,7 +190,9 @@ class LoggerPool(ThreadPool):
 
                 try:
                     log.write(data)
-                except (OSError, IOError) as e:  # pragma: no cover
+
+                # pragma: no cover
+                except (OSError, IOError, WindowsError) as e:
                     # Put the log message back in the queue
                     # so we're not losing data.  It may be lightly
                     # out of order now but we have a date stamp
@@ -200,7 +207,9 @@ class LoggerPool(ThreadPool):
             if processed:
                 try:
                     log.file.flush()
-                except (OSError, IOError) as e:  # pragma: no cover
+
+                # pragma: no cover
+                except (OSError, IOError, WindowsError) as e:
                     logger.error(
                         "Failed to flush output to %s: %s",
                         log.file.name, e)

--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -17,7 +17,7 @@
 from collections import deque
 from datetime import datetime
 from errno import EEXIST
-from threading import Lock, RLock
+from threading import RLock
 from os import makedirs
 from os.path import dirname, isfile
 
@@ -183,10 +183,12 @@ class LoggerPool(ThreadPool):
             while lines_written < num_messages:
                 try:
                     data = log.messages.popleft()
-                    log.write(data)
-                    lines_written += 1
                 except IndexError:
                     break
+
+                try:
+                    log.write(data)
+                    lines_written += 1
                 except (OSError, IOError) as e:  # pragma: no cover
                     # Put the log message back in the queue
                     # so we're not losing data.  It may be lightly


### PR DESCRIPTION
This PR cleans up the internals of flush some and also ensures that we handle `WindowsError` when it's available.  Found most of these improvements while working #303, figured they could be broken out.