### PR TITLE
Improve Agent.post_shutdown_to_master tests.

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -697,6 +697,7 @@ class Agent(object):
                     yield pause
 
                 else:
+                    timed_out = True
                     svclog.warning(
                         "State update failed due to unhandled error: %s.  "
                         "Shutdown timeout reached, not retrying.",
@@ -739,13 +740,18 @@ class Agent(object):
                         break
 
         yield self.post_shutdown_lock.release()
+        extra_data = {
+            "response": response,
+            "timed_out": timed_out,
+            "tries": tries,
+            "retry_errors": num_retry_errors
+        }
+
         if isinstance(data, dict):
-            data.update(
-                response=response,
-                timed_out=timed_out,
-                tries=tries,
-                retry_errors=num_retry_errors
-            )
+            data.update(extra_data)
+        else:
+            data = extra_data
+
         returnValue(data)
 
     @inlineCallbacks

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -649,6 +649,7 @@ class Agent(object):
         # stop the reactor from finishing we perform the retry in-line
         data = None
         num_retry_errors = 0
+        response = None
         while True:
             try:
                 response = yield post_direct(
@@ -734,6 +735,7 @@ class Agent(object):
                         break
 
         yield self.post_shutdown_lock.release()
+        data.update(response=response)
         returnValue(data)
 
     @inlineCallbacks

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -648,10 +648,12 @@ class Agent(object):
         # Because post_shutdown_to_master is blocking and needs to
         # stop the reactor from finishing we perform the retry in-line
         data = None
+        tries = 0
         num_retry_errors = 0
         response = None
         timed_out = False
         while True:
+            tries += 1
             try:
                 response = yield post_direct(
                     self.agent_api(),
@@ -738,7 +740,12 @@ class Agent(object):
 
         yield self.post_shutdown_lock.release()
         if isinstance(data, dict):
-            data.update(response=response, timed_out=timed_out)
+            data.update(
+                response=response,
+                timed_out=timed_out,
+                tries=tries,
+                retry_errors=num_retry_errors
+            )
         returnValue(data)
 
     @inlineCallbacks

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -35,7 +35,6 @@ except ImportError:  # pragma: no cover
 from mock import patch, Mock
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, DeferredList, inlineCallbacks
-from twisted.internet.task import deferLater
 from twisted.python.failure import Failure
 from twisted.web.resource import Resource
 from twisted.web.server import Site, NOT_DONE_YET

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -481,6 +481,7 @@ class TestPostShutdownToMaster(TestCase):
             yield agent.post_shutdown_to_master()
 
         self.assertEqual(agent.post_shutdown_lock.waiting, [])
+        self.assertEqual(self.fake_api.requests, [])
 
     @inlineCallbacks
     def test_post_not_found(self):

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -477,7 +477,7 @@ class TestPostShutdownToMaster(TestCase):
         if should_retry:
             self.assertGreaterEqual(tries, 2)
         else:
-            self.assertEqual(tries, 0)
+            self.assertEqual(tries, 1)
 
         if retry_errors:
             self.assertGreaterEqual(num_retry_errors, 2)

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -605,7 +605,7 @@ class TestPostShutdownToMaster(TestCase):
         agent.shutting_down = True
         agent.shutdown_timeout = datetime.utcnow() + timedelta(hours=1)
         reactor.callLater(
-            .5, setattr, agent, "shutdown_timeout", datetime.utcnow())
+            3, setattr, agent, "shutdown_timeout", datetime.utcnow())
 
         with AssertLockReleased(self, agent.post_shutdown_lock):
             result = yield agent.post_shutdown_to_master()

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -473,8 +473,10 @@ class TestPostShutdownToMaster(TestCase):
     @inlineCallbacks
     def test_assert_shutting_down(self):
         agent = Agent()
-        agent.shutting_down = False
+        agent.shutting_down = False  # This should cause AssertionError to raise
 
+        # The assertion statement should come before
+        # we ever try to acquire and release any locks.
         with nested(
             patch.object(agent.post_shutdown_lock, "acquire"),
             patch.object(agent.post_shutdown_lock, "release"),

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -475,17 +475,12 @@ class TestPostShutdownToMaster(TestCase):
         agent = Agent()
         agent.shutting_down = False  # This should cause AssertionError to raise
 
-        # The assertion statement should come before
-        # we ever try to acquire and release any locks.
-        with nested(
-            patch.object(agent.post_shutdown_lock, "acquire"),
-            patch.object(agent.post_shutdown_lock, "release"),
-            self.assertRaises(AssertionError)
-        ) as (acquire, release, _):
+        self.assertEqual(agent.post_shutdown_lock.waiting, [])
+
+        with self.assertRaises(AssertionError):
             yield agent.post_shutdown_to_master()
 
-        self.assertFalse(acquire.called)
-        self.assertFalse(release.called)
+        self.assertEqual(agent.post_shutdown_lock.waiting, [])
 
     @inlineCallbacks
     def test_post_not_found(self):


### PR DESCRIPTION
This PR was created to simplify some of the tests for Agent.post_shutdown_to_master.  Mostly it removes many of the mocks and adds some additional output to post_shutdown_to_master that we can use when testing.  This also improves on a few tests that we inconsistently passing while working on #303.