### PR TITLE
Improve Usage of disks.disks()

### DIFF
--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -257,17 +257,16 @@ class Agent(object):
         num_retry_errors = 0
         while True:  # for retries
             try:
-                agent_data = {
-                    "state": config["state"],
-                    "current_assignments": config.get(
-                        "current_assignments", {}),  # may not be set yet
-                    "free_ram": memory.free_ram(),
-                    "disks": disks.disks(as_dict=True)
-                }
-
                 response = yield post_direct(
                     self.agent_api(),
-                    data=agent_data
+                    data={
+                        "state": config["state"],
+                        "current_assignments": config.get(
+                            "current_assignments", {} # may not be set yet
+                        ),
+                        "free_ram": memory.free_ram(),
+                        "disks": disks.disks(as_dict=True)
+                    }
                 )
 
             except (ResponseNeverReceived, RequestTransmissionFailed) as error:

--- a/pyfarm/agent/service.py
+++ b/pyfarm/agent/service.py
@@ -258,18 +258,13 @@ class Agent(object):
         while True:  # for retries
             try:
                 agent_data = {
-                        "state": config["state"],
-                        "current_assignments": config.get(
-                            "current_assignments", {}),  # may not be set yet
-                        "free_ram": memory.free_ram()}
-                try:
-                    local_disks = disks.disks()
-                    agent_data["disks"] = [{"mountpoint": x.mountpoint,
-                                "free": x.free,
-                                "size": x.size}
-                                for x in local_disks]
-                except Exception as e:
-                    svclog.warning("Could not read disks: %r", e)
+                    "state": config["state"],
+                    "current_assignments": config.get(
+                        "current_assignments", {}),  # may not be set yet
+                    "free_ram": memory.free_ram(),
+                    "disks": disks.disks(as_dict=True)
+                }
+
                 response = yield post_direct(
                     self.agent_api(),
                     data=agent_data
@@ -409,22 +404,15 @@ class Agent(object):
             "state": config["state"],
             "mac_addresses": list(network.mac_addresses()),
             "current_assignments": config.get(
-                "current_assignments", {})}  # may not be set yet
+                "current_assignments", {}), # may not be set yet
+            "disks": disks.disks(as_dict=True)
+        }
 
         try:
             gpu_names = graphics.graphics_cards()
             data["gpus"] = gpu_names
         except graphics.GPULookupError:
             pass
-
-        try:
-            local_disks = disks.disks()
-            data["disks"] = [{"mountpoint": x.mountpoint,
-                              "free": x.free,
-                              "size": x.size}
-                             for x in local_disks]
-        except Exception as e:
-            svclog.warning("Could not read disks: %r", e)
 
         if "remote_ip" in config:
             data.update(remote_ip=config["remote_ip"])

--- a/pyfarm/agent/sysinfo/disks.py
+++ b/pyfarm/agent/sysinfo/disks.py
@@ -35,7 +35,13 @@ logger = getLogger("agent.disks")
 
 def disks(as_dict=False):
     """
-    Returns a list of disks in the system, in the form of DiskInfo objects
+    Returns a list of disks in the system, in the form of :class:`DiskInfo`
+    objects.
+
+    :param bool as_dict:
+        If True then return a dictionary value instead of :class:`DiskInfo`
+        instances.  This is mainly used by the agent to eliminate an extra
+        loop for translation.
     """
     out = []
     for partition in psutil.disk_partitions():

--- a/pyfarm/agent/sysinfo/disks.py
+++ b/pyfarm/agent/sysinfo/disks.py
@@ -33,7 +33,7 @@ DiskInfo = namedtuple("DiskInfo", ("mountpoint", "free", "size"))
 logger = getLogger("agent.disks")
 
 
-def disks():
+def disks(as_dict=False):
     """
     Returns a list of disks in the system, in the form of DiskInfo objects
     """
@@ -49,10 +49,19 @@ def disks():
         except OSError:
             continue
 
-        info = DiskInfo(
-            mountpoint=partition.mountpoint,
-            free=usage.free,
-            size=usage.total)
+        if not as_dict:
+            info = DiskInfo(
+                mountpoint=partition.mountpoint,
+                free=usage.free,
+                size=usage.total
+            )
+        else:
+            info = {
+                "mountpoint": partition.mountpoint,
+                "free": usage.free,
+                "size": usage.total
+            }
+
         out.append(info)
 
     return out

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -90,11 +90,12 @@ class FakeAgentsAPI(HTTPReceiver):
 
 class TestSystemData(TestCase):
     def test_system_data(self):
+        disk_data = [{"free": 50000, "mountpoint": "/", 'size': 100000}]
         config["remote_ip"] = os.urandom(16).encode("hex")
         expected = {
             "id": config["agent_id"],
             "current_assignments": {},
-            "disks": [{"free": 50000, "mountpoint": "/", 'size': 100000}],
+            "disks": disk_data,
             "hostname": config["agent_hostname"],
             "version": config.version,
             "ram": config["agent_ram"],
@@ -111,7 +112,10 @@ class TestSystemData(TestCase):
         }
 
         agent = Agent()
-        with patch.object(graphics, "graphics_cards", return_value=[1, 3, 5]):
+        with nested(
+            patch.object(graphics, "graphics_cards", return_value=[1, 3, 5]),
+            patch.object(disks, "disks", return_value=disk_data)
+        ):
             system_data = agent.system_data()
 
         self.assertApproximates(

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -926,7 +926,10 @@ class TestReannounce(TestCase):
 
         # Mock out disks.disks
         self.disks_mock = patch.object(
-            disks, "disks", return_value=[disks.DiskInfo("/", 50000, 100000)])
+            disks, "disks", return_value=[{
+                "mountpoint": "/",
+                "size": 100000,
+                "free": 50000}])
         self.disks_mock.start()
 
         self.normal_result = {

--- a/tests/test_agent/test_service.py
+++ b/tests/test_agent/test_service.py
@@ -923,6 +923,7 @@ class TestReannounce(TestCase):
         self.free_ram_mock = patch.object(
             memory, "free_ram", return_value=424242)
         self.free_ram_mock.start()
+        self.addCleanup(self.free_ram_mock.stop)
 
         # Mock out disks.disks
         self.disks_mock = patch.object(
@@ -931,6 +932,7 @@ class TestReannounce(TestCase):
                 "size": 100000,
                 "free": 50000}])
         self.disks_mock.start()
+        self.addCleanup(self.disks_mock.stop)
 
         self.normal_result = {
             "state": config["state"],
@@ -945,7 +947,6 @@ class TestReannounce(TestCase):
     @inlineCallbacks
     def tearDown(self):
         super(TestReannounce, self).tearDown()
-        self.free_ram_mock.stop()
         yield self.server.loseConnection()
 
     @inlineCallbacks


### PR DESCRIPTION
Since we're catching OSError inside of disks.disks() we shouldn't need the bare try/except clause anymore.  This PR also adds the tests for disks.disks() and provides a `as_dict` keyword so we can skip the extra for loop in service.py