### PR TITLE
Remove warning about PyOpenSSL in setup.py on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,12 @@
 
 from __future__ import with_statement
 
-import sys
-assert sys.version_info[0:2] >= (2, 6), "Python 2.6 or higher is required"
-
 import os
+import sys
 from os import walk
 from os.path import isfile, join
 from setuptools import setup
+assert sys.version_info[0:2] >= (2, 6), "Python 2.6 or higher is required"
 
 install_requires = [
     "pyfarm.core>=0.9.3",

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,3 @@ setup(
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Topic :: System :: Distributed Computing"])
-
-if sys.platform.startswith("win"):
-    print("WARNING:  Please be sure you've installed the OpenSSL Library as "
-          "some modules may break on Windows without it.")


### PR DESCRIPTION
Comment on ea11331 should explain most of the reasoning behind this.  I decided to remove the warning after seeing that on Windows this warning is usually shown to a user several times.  Additionally you can't really tell which package the warning came from which is misleading and could lead someone to believe something is wrong when there probably isn't.