### PR TITLE
Lower some of the logging calls in core/log.py to DEBUG

### DIFF
--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -149,7 +149,7 @@ class LoggerPool(ThreadPool):
         if log is not None:
             self.flush(log)
             log.file.close()
-            logger.info("Closed %s", log.file.name)
+            logger.debug("Closed %s", log.file.name)
 
     def log(self, uuid, stream, message, pid=None):
         """
@@ -227,7 +227,7 @@ class LoggerPool(ThreadPool):
         if not self.started or self.joined:
             return
         
-        logger.info("Logging thread pool is shutting down.")
+        logger.debug("Logging thread pool is shutting down.")
         self.stopped = True
 
         for protocol_id in list(self.logs.keys()):
@@ -242,7 +242,7 @@ class LoggerPool(ThreadPool):
         """
         reactor.addSystemEventTrigger("before", "shutdown", self.stop)
         ThreadPool.start(self)
-        logger.info(
+        logger.debug(
             "Started logger thread pool (min=%s, max=%s)", self.min, self.max)
 
 try:


### PR DESCRIPTION
The log emissions in this change should be DEBUG rather than
INFO.  Either a jobtype would be logging the file path, the
information we're logging is not useful outside of debug/testing or
there are other way we'd find out there's a problem (such as an
exception being raised).