### PR TITLE
Capture Logging/Silence tests in setUp

### DIFF
--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -38,7 +38,6 @@ except ImportError:  # pragma: no cover
 
 from jinja2 import Template
 from twisted.internet.base import DelayedCall
-from twisted.python.log import theLogPublisher
 from twisted.trial.unittest import TestCase as _TestCase, SkipTest, FailTest
 from twisted.web.test.requesthelper import DummyRequest as _DummyRequest
 

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -36,6 +36,7 @@ except ImportError:  # pragma: no cover
     from http.client import OK, CREATED
 
 from jinja2 import Template
+from mock import patch
 from twisted.internet.base import DelayedCall
 from twisted.trial.unittest import TestCase as _TestCase, SkipTest, FailTest
 from twisted.web.test.requesthelper import DummyRequest as _DummyRequest
@@ -367,13 +368,14 @@ class TestCase(_TestCase):
         def skipTest(self, reason):
             raise SkipTest(reason)
 
-    # If the config logger really needs to be turned on someone
-    # can do so in setUp.  This is pretty verbose and will make
-    # it difficult to debug tests.
-    config_logger.disabled = True
-
     def setUp(self):
         super(TestCase, self).setUp()
+
+        # Disable config logging
+        self._config_logger_disabled = config_logger.disabled
+        config_logger.disabled = True
+        self.addCleanup(
+            setattr, config_logger, "disabled", self._config_logger_disabled)
 
         try:
             self._pop_config_keys

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -256,7 +256,7 @@ class DummyRequest(_DummyRequest):
 
 class TestCaseLogHandler(logging.Handler):
     def __init__(self, level=logging.DEBUG):
-        super(TestCaseLogHandler, self).__init__(level=level)
+        logging.Handler.__init__(self, level=level)
         self.records = []
 
     def handle(self, record):

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -23,7 +23,6 @@ import time
 import uuid
 from datetime import datetime
 from functools import wraps, partial
-from logging import FATAL, getLogger
 from os import urandom
 from os.path import basename, isfile
 from random import randint, choice
@@ -44,8 +43,8 @@ from twisted.web.test.requesthelper import DummyRequest as _DummyRequest
 from pyfarm.core.config import read_env
 from pyfarm.core.enums import AgentState, PY26, STRING_TYPES
 from pyfarm.agent.http.core.client import post
-from pyfarm.agent.config import config, logger as config_logger
-from pyfarm.agent.logger.twistd import CONFIGURATION, Observer
+from pyfarm.agent.config import config
+from pyfarm.agent.logger.twistd import Observer
 from pyfarm.agent.sysinfo import memory, cpu
 from pyfarm.agent.utility import dumps, remove_directory
 


### PR DESCRIPTION
For comparison, here's the new output: https://travis-ci.org/pyfarm/pyfarm-agent/jobs/77930978
And here's the old output: https://travis-ci.org/pyfarm/pyfarm-agent/jobs/77850694

There's still a couple of places we're emitting output, but those will not be as easy to capture because of the context in which the logger is being used.
