### PR TITLE
Remove dependency on pyfarm-master from unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,11 @@ python:
   - 2.6
   - 2.7
 
-services:
-  - redis-server
-
 cache:
   directories:
   - $HOME/.pipcache
 
 env:
-  global:
-    - VIRTUALENV_ROOT=/tmp/virtualenv
-    - VIRTUALENV_MASTER=$VIRTUALENV_ROOT/pyfarm-master
-    - VIRTUALENV_AGENT=$VIRTUALENV_ROOT/pyfarm-agent
-    - PIP_DOWNLOAD_CACHE=$HOME/.pipcache
-    - MASTER_PYTHON_VERSION=3.4
-    - PYFARM_AGENT_TEST_MASTER=127.0.0.1:5000  # where uwsgi is running
-    - TDB_TYPE=postgres TDB_DRIVER=psycopg2 PYFARM_DATABASE_URI="postgresql+psycopg2://postgres:@127.0.0.1/pyfarm" PYFARM_CONFIG="prod" PYFARM_SECRET_KEY="travis"
-
   # TODO: test the agent against multiple configurations, independent of DB configuration.
   # NOTE: Do not use sqlite here as it breaks because of concurrency issues
   matrix:
@@ -33,32 +21,11 @@ matrix:
 before_install:
   - curl -o retry.sh https://raw.githubusercontent.com/pyfarm/pyfarm-build/master/travis/retry.sh
   - source retry.sh
-  - mkdir -p $PIP_DOWNLOAD_CACHE
-
-  # Create virtual environments for agent and master
-  - deactivate  # travis virtualenv
-  - virtualenv -p python$TRAVIS_PYTHON_VERSION $VIRTUALENV_AGENT
-  - virtualenv -p python$MASTER_PYTHON_VERSION $VIRTUALENV_MASTER
 
 install:
-  # Master installation
-  - . $VIRTUALENV_MASTER/bin/activate
-  - if [[ $TDB_TYPE == "postgres" ]]; then psql -c "create database pyfarm;" -U postgres; fi
-  - if [[ $TDB_TYPE == "mysql" ]]; then mysql -e "create database pyfarm;"; fi
-  - if [[ $TDB_DRIVER != "" ]]; then retry pip install $TDB_DRIVER --quiet; fi
-  - retry pip install uwsgi --quiet
-  - retry pip install -e git+git://github.com/pyfarm/pyfarm-core.git#egg=pyfarm.core --egg --quiet
-  - retry pip install -e git+git://github.com/pyfarm/pyfarm-master.git#egg=pyfarm.master --egg --quiet
-  - pyfarm-tables --echo
-  - uwsgi resources/uwsgi.ini
-  - pip freeze
-  - deactivate  # master virtualenv
-
   # Agent installation
-  - . $VIRTUALENV_AGENT/bin/activate
   - retry pip install coverage python-coveralls mock --quiet
   - if [[ $PYFARM_AGENT_TEST_HTTP_SCHEME == "https" ]]; then retry pip install PyOpenSSL service_identity --quiet; fi
-  - retry pip install -e git+git://github.com/pyfarm/pyfarm-core.git#egg=pyfarm.core --egg --quiet
   - retry pip install -e . --egg --quiet
   - pip freeze
 
@@ -71,6 +38,3 @@ script:
 
 after_success:
   - coveralls
-
-after_failure:
-  - cat /tmp/uwsgi.log

--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,9 @@ on platform)::
 Testing
 -------
 
-Tests are run on `Travis <https://travis-ci.org/pyfarm/pyfarm-agent>`_ for
-every commit.  They can also be run locally too using ``trial``.  They will
+Tests are run on `Travis <https://travis-ci.org/pyfarm/pyfarm-agent>`_ and
+`Appveyor <https://ci.appveyor.com/project/opalmer/pyfarm-agent/history>`_ for
+every commit.  They can also be run locally too using ``trial``.   They will
 require access to https://httpbin.pyfarm.net unless you plan on skipping or
 ignoring some of the http client failures.
 
@@ -88,5 +89,5 @@ line calls::
     you don't have another package for PyFarm installed in your system
     site-packages directory.
 
-    You may alsohave to run trial a little differently.  See
+    You may also have to run trial a little differently.  See
     ``appveyor.yml`` for an example.

--- a/README.rst
+++ b/README.rst
@@ -58,29 +58,29 @@ Testing
 -------
 
 Tests are run on `Travis <https://travis-ci.org/pyfarm/pyfarm-agent>`_ for
-every commit.  They can also be run locally too using ``trial``.  Currently,
-the agent tests require:
+every commit.  They can also be run locally too using ``trial``.  They will
+require access to https://httpbin.pyfarm.net unless you plan on skipping or
+ignoring some of the http client failures.
 
-    * Access to https://httpbin.pyfarm.net for HTTP client testing.  This is
-      configurable however and could be pointed to an internal domain
-      using the ``agent_unittest`` configuration variable.
-    * The ``pyfarm.master`` module to run the API.  So all the setup steps
-      that apply to the master will apply here as well.  This includes the
-      requirement to run Redis, RabbitMQ or another backend that supports
-      ``celery``.
-    * Linux or OS X since the master is designed to operate on these
-      platforms.  The below setup may work on Windows with a few configuration
-      tweaks too.
-
-Newer tests are being designed to be lighter weight so eventually most of the
-above may no longer be required for testing.  For now however these are the
-basic steps to run the tests and are based on the steps in ``.travis.yml``::
+To execute the tests in Linux or OS X, try this::
 
     virtualenv env
     . env/bin/activate
-    pip install pyfarm.master uwsgi mock
-    pyfarm-tables
-    uwsgi resources/uwsgi.ini
     pip install -e . --egg
-    trial tests  # in a new shell with the same virtualenv
+    trial tests
+
+On Windows the process is similar but requires a few changes to the command
+line calls::
+
+    virtualenv env
+    env\Scripts\activate
+    %VIRTUALE_ENV%\Scripts\pip.exe install wheel
+    %VIRTUALE_ENV%\Scripts\pip.exe install -e . --egg
+    %VIRTUALE_ENV%\Scripts\python.exe %VIRTUALE_ENV%\Scripts\trial.py tests
+
+.. note::
+
+    On Windows, if the tests fail to locate one of the agent's modules be sure
+    you don't have another package for PyFarm installed in your system
+    site-packages directory.
 

--- a/pyfarm/agent/testutil.py
+++ b/pyfarm/agent/testutil.py
@@ -134,19 +134,6 @@ def random_port(bind="127.0.0.1"):
         sock.close()
 
 
-def requires_master(function):
-    """
-    Any test decorated with this function will fail if the master could
-    not be contacted or returned a response other than 200 OK for "/"
-    """
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        if not PYFARM_MASTER_API_ONLINE:
-            raise FailTest("Could not connect to master")
-        return function(*args, **kwargs)
-    return wrapper
-
-
 def create_jobtype(classname=None, sourcecode=None):
     """Creates a job type on the master and fires a deferred when finished"""
     if classname is None:

--- a/tests/test_agent/test_http_api_state.py
+++ b/tests/test_agent/test_http_api_state.py
@@ -156,4 +156,6 @@ class TestStatus(BaseAPITestCase):
         self.assertTrue(request.finished)
         self.assertEqual(request.responseCode, OK)
         self.assertEqual(len(request.written), 1)
-        self.assertEqual(loads(request.written[0]), expected_data)
+        self.assertEqual(
+            dumps(loads(request.written[0]), sort_keys=True),
+            dumps(expected_data, sort_keys=True))

--- a/tests/test_agent/test_http_api_state.py
+++ b/tests/test_agent/test_http_api_state.py
@@ -85,8 +85,6 @@ class TestStatus(BaseAPITestCase):
     URI = "/status"
     CLASS = Status
 
-    maxDiff = None
-
     def setUp(self):
         super(TestStatus, self).setUp()
         self._config = config.copy()
@@ -158,7 +156,4 @@ class TestStatus(BaseAPITestCase):
         self.assertTrue(request.finished)
         self.assertEqual(request.responseCode, OK)
         self.assertEqual(len(request.written), 1)
-        self.assertEqual(
-            loads(request.written[0]),
-            loads(dumps(expected_data))
-        )
+        self.assertEqual(request.written[0], expected_data)

--- a/tests/test_agent/test_http_api_state.py
+++ b/tests/test_agent/test_http_api_state.py
@@ -15,17 +15,17 @@
 # limitations under the License.
 
 import time
-from json import loads
 from contextlib import nested
 from datetime import datetime, timedelta
+from json import loads
 
 try:
     from httplib import ACCEPTED, OK, BAD_REQUEST
 except ImportError:  # pragma: no cover
     from http.client import ACCEPTED, OK, BAD_REQUEST
 
-import psutil
 import mock
+import psutil
 from twisted.web.server import NOT_DONE_YET
 from twisted.internet import reactor
 

--- a/tests/test_agent/test_http_api_state.py
+++ b/tests/test_agent/test_http_api_state.py
@@ -17,7 +17,7 @@
 import time
 from contextlib import nested
 from datetime import datetime, timedelta
-from json import loads
+from json import loads, dumps
 
 try:
     from httplib import ACCEPTED, OK, BAD_REQUEST
@@ -158,4 +158,7 @@ class TestStatus(BaseAPITestCase):
         self.assertTrue(request.finished)
         self.assertEqual(request.responseCode, OK)
         self.assertEqual(len(request.written), 1)
-        self.assertEqual(loads(request.written[0]), expected_data)
+        self.assertEqual(
+            loads(request.written[0]),
+            loads(dumps(expected_data))
+        )

--- a/tests/test_agent/test_http_api_state.py
+++ b/tests/test_agent/test_http_api_state.py
@@ -156,4 +156,4 @@ class TestStatus(BaseAPITestCase):
         self.assertTrue(request.finished)
         self.assertEqual(request.responseCode, OK)
         self.assertEqual(len(request.written), 1)
-        self.assertEqual(request.written[0], expected_data)
+        self.assertEqual(loads(request.written[0]), expected_data)

--- a/tests/test_agent/test_http_api_state.py
+++ b/tests/test_agent/test_http_api_state.py
@@ -85,6 +85,8 @@ class TestStatus(BaseAPITestCase):
     URI = "/status"
     CLASS = Status
 
+    maxDiff = None
+
     def setUp(self):
         super(TestStatus, self).setUp()
         self._config = config.copy()

--- a/tests/test_jobtypes/test_core_internals.py
+++ b/tests/test_jobtypes/test_core_internals.py
@@ -46,8 +46,7 @@ from twisted.internet import reactor
 from twisted.internet.defer import Deferred
 
 from pyfarm.core.enums import STRING_TYPES, LINUX, MAC, WINDOWS, BSD, WorkState
-from pyfarm.agent.testutil import (
-    TestCase, skipIf, requires_master, create_jobtype)
+from pyfarm.agent.testutil import TestCase, skipIf, create_jobtype
 from pyfarm.agent.config import config
 from pyfarm.agent.sysinfo import user
 from pyfarm.jobtypes.core.internals import (
@@ -116,7 +115,6 @@ class TestCache(TestCase):
     def test_cache_directory(self):
         self.assertTrue(isdir(Cache.CACHE_DIRECTORY))
 
-    @requires_master
     def test_download(self):
         classname = "AgentUnittest" + os.urandom(8).encode("hex")
         created = create_jobtype(classname=classname)


### PR DESCRIPTION
This PR removes the requirement to run the master in order for all tests to pass.  #303 also benefits from this because it will normalize test execution on Travis and Appveyor.