### PR TITLE
Don't delay restart for a non-running assignment

### DIFF
--- a/pyfarm/agent/http/api/state.py
+++ b/pyfarm/agent/http/api/state.py
@@ -109,7 +109,7 @@ class Restart(APIResource):
                 logger.info("Created run control file %s",
                             config["run_control_file"])
 
-        if not config["current_assignments"] or data.get("immediately", False):
+        if not config["jobtype"] or data.get("immediately", False):
             logger.info("The agent will restart immediately.")
             stopping = agent.stop()
             stopping.addCallbacks(lambda _: reactor.stop(),


### PR DESCRIPTION
The previous code could get the agent stuck in an endless loop, because
the code that checks whether the agent should restart comes before the
code that removes the jobtype from config