### PR TITLE
Fix restart API endpoint

### DIFF
--- a/pyfarm/agent/http/api/state.py
+++ b/pyfarm/agent/http/api/state.py
@@ -109,7 +109,8 @@ class Restart(APIResource):
                 logger.info("Created run control file %s",
                             config["run_control_file"])
 
-        if not config["jobtype"] or data.get("immediately", False):
+        if ("jobtypes" not in config or not config["jobtypes"] or
+            data.get("immediately", False)):
             logger.info("The agent will restart immediately.")
             stopping = agent.stop()
             stopping.addCallbacks(lambda _: reactor.stop(),


### PR DESCRIPTION
jobtypes was misspelled and the endpoint would fail when there was no
"jobtypes" in config yet.