### PR TITLE
Full test coverage for sysinfo.software

### DIFF
--- a/pyfarm/agent/sysinfo/software.py
+++ b/pyfarm/agent/sysinfo/software.py
@@ -142,8 +142,8 @@ def get_discovery_code(software, version):
             yield deferred
 
         else:
-            data = yield treq.content(response)
             if response.code == OK:
+                data = yield treq.content(response)
                 returnValue(data)
 
             elif response.code >= INTERNAL_SERVER_ERROR:

--- a/pyfarm/agent/sysinfo/software.py
+++ b/pyfarm/agent/sysinfo/software.py
@@ -80,8 +80,8 @@ def get_software_version_data(software, version):
             yield deferred
 
         else:
-            data = yield treq.json_content(response)
             if response.code == OK:
+                data = yield treq.json_content(response)
                 returnValue(data)
 
             elif response.code >= INTERNAL_SERVER_ERROR:

--- a/pyfarm/agent/sysinfo/software.py
+++ b/pyfarm/agent/sysinfo/software.py
@@ -32,8 +32,7 @@ import imp, sys
 import treq
 
 from twisted.internet import reactor, threads
-from twisted.internet.defer import (
-    inlineCallbacks, returnValue, Deferred, DeferredList)
+from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
 
 from pyfarm.agent.logger import getLogger
 from pyfarm.agent.config import config


### PR DESCRIPTION
As the title says, this PR is improving on the coverage for `sysinfo.software`.  Original coverage is captured here: https://coveralls.io/builds/3655258/source?filename=pyfarm%2Fagent%2Fsysinfo%2Fsoftware.py