### PR TITLE
Modify assign API to respond directly with tuples

### DIFF
--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -193,12 +193,6 @@ class Assign(APIResource):
         assignment_uuid = uuid4()
         request_data.update(id=assignment_uuid)
         config["current_assignments"][assignment_uuid] = request_data
-
-        # In all other cases we have some work to do inside of
-        # deferreds so we just have to respond
-        request.setResponseCode(ACCEPTED)
-        request.write(dumps({"id": assignment_uuid}))
-        request.finish()
         logger.debug("Accepted assignment %s: %r",
                      assignment_uuid, request_data)
         logger.info("Accept assignment from job %s with %s tasks",

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -161,22 +161,20 @@ class Assign(APIResource):
 
             # If the assignment is identical to one we already have
             if existing_task_ids == new_task_ids:
-                logger.debug("Ignoring repeated assignment of the same batch")
-                request.setResponseCode(ACCEPTED)
-                request.write(dumps({"id": assignment["id"]}))
-                request.finish()
-                return NOT_DONE_YET
+                logger.debug(
+                    "Ignoring repeated assignment of the same batch")
+                return dumps({"id": assignment["id"]}), ACCEPTED
+
             # If there is only a partial overlap
             elif existing_task_ids & new_task_ids:
                 logger.error("Rejecting assignment with partial overlap with "
                              "existing assignment.")
                 unknown_task_ids = new_task_ids - existing_task_ids
-                request.setResponseCode(CONFLICT)
-                request.write(dumps(
-                    {"error": "Partial overlap of tasks",
-                     "rejected_task_ids": list(unknown_task_ids)}))
-                request.finish()
-                return NOT_DONE_YET
+                return (
+                    dumps({"error": "Partial overlap of tasks",
+                           "rejected_task_ids": list(unknown_task_ids)}),
+                    CONFLICT
+                )
 
         if not config["agent_allow_sharing"]:
             try:

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -27,7 +27,6 @@ except ImportError:  # pragma: no cover
 import traceback
 from functools import partial
 
-from twisted.web.server import NOT_DONE_YET
 from twisted.internet import reactor
 from twisted.internet.defer import DeferredList
 from voluptuous import Schema, Required
@@ -372,4 +371,4 @@ class Assign(APIResource):
         jobtype_loader.addCallback(loaded_jobtype, assignment_uuid)
         jobtype_loader.addErrback(load_jobtype_failed, assignment_uuid)
 
-        return NOT_DONE_YET
+        return dumps({"id": assignment_uuid}), ACCEPTED

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -154,15 +154,9 @@ class Assign(APIResource):
                 BAD_REQUEST
             )
 
-        # Check for double assignments
-        try:
-            current_assignments = config["current_assignments"].itervalues
-        except AttributeError:  # pragma: no cover
-            current_assignments = config["current_assignments"].values
-
         new_task_ids = set(task["id"] for task in request_data["tasks"])
 
-        for assignment in current_assignments():
+        for assignment in config["current_assignments"].itervalues():
             existing_task_ids = set(x["id"] for x in assignment["tasks"])
 
             # If the assignment is identical to one we already have

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -183,13 +183,13 @@ class Assign(APIResource):
                 if len(jobtype.assignment["tasks"]) > num_finished_tasks:
                     logger.error("Rejecting an assignment that would require "
                                  "agent sharing")
-                    request.setResponseCode(CONFLICT)
-                    request.write(
-                    dumps({"error":
-                               "Agent does not allow multiple assignments",
-                           "rejected_task_ids": list(new_task_ids)}))
-                    request.finish()
-                    return NOT_DONE_YET
+                    return (
+                        dumps({
+                            "error": "Agent does not allow multiple "
+                                     "assignments",
+                            "rejected_task_ids": list(new_task_ids)}),
+                        CONFLICT
+                    )
 
         assignment_uuid = uuid4()
         request_data.update(id=assignment_uuid)

--- a/pyfarm/agent/http/api/assign.py
+++ b/pyfarm/agent/http/api/assign.py
@@ -177,11 +177,7 @@ class Assign(APIResource):
                 )
 
         if not config["agent_allow_sharing"]:
-            try:
-                current_jobtypes = config["jobtypes"].itervalues
-            except AttributeError:  # pragma: no cover
-                current_jobtypes = config["jobtypes"].values
-            for jobtype in current_jobtypes():
+            for jobtype in config["jobtypes"].itervalues():
                 num_finished_tasks = (len(jobtype.finished_tasks) +
                                       len(jobtype.failed_tasks))
                 if len(jobtype.assignment["tasks"]) > num_finished_tasks:

--- a/tests/test_agent/test_http_api_assign.py
+++ b/tests/test_agent/test_http_api_assign.py
@@ -124,7 +124,7 @@ class TestAssign(BaseAPITestCase):
         self.assertEqual(len(request.written), 1)
         self.assertEqual(
             loads(request.written[0])["error"],
-            "Agent cannot accept assignments because of a pending restart")
+            u"Agent cannot accept assignments because of a pending restart.")
 
     def test_agent_id_not_set(self):
         config.pop("agent_id", None)


### PR DESCRIPTION
So while working on #334 it's become more apparent that in order to handle exceptions properly and generally cleanup the assignment APIs we need to do a little work converting it to inlineCallbacks.  Otherwise we can end up with a response going back to a client before a job type is actually loaded causing exceptions to possibly swallowed.

The modification of the assignment API to use inlineCallbacks will be broken down into another CL but for now this PR modifies some of the code from this style of response:

```python
request.setResponseCode(ACCEPTED)
request.write(dumps({"id": assignment_uuid}))
request.finish()
return NOT_DONE_YET
```

to:

```python
return dumps({"id": assignment_uuid}), ACCEPTED
```

This approach is cleaner and tightens the coupling some between the request being made and when the response is sent.