### PR TITLE
Protect only $TMP/pyfarm from deletion

### DIFF
--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -825,7 +825,7 @@ class System(object):
         for root, dirs, files in os.walk(tempdir, topdown=True,
                                          followlinks=False):
             # Don't delete our own temp files
-            if "pyfarm" in dirs:
+            if root == tempdir and "pyfarm" in dirs:
                 dirs.remove("pyfarm")
             for filename in files:
                 fullpath = join(root, filename)

--- a/pyfarm/jobtypes/core/internals.py
+++ b/pyfarm/jobtypes/core/internals.py
@@ -825,8 +825,9 @@ class System(object):
         for root, dirs, files in os.walk(tempdir, topdown=True,
                                          followlinks=False):
             # Don't delete our own temp files
-            if root == tempdir and "pyfarm" in dirs:
-                dirs.remove("pyfarm")
+            if root == dirname(config.tempdir):
+                dirs[:] = []  # Do not iterate over sub directories in this root
+                continue
             for filename in files:
                 fullpath = join(root, filename)
                 stat_result = os.stat(fullpath)


### PR DESCRIPTION
As opposed to directory named "pyfarm" anywhere under $TMP
