### PR TITLE
Fix test_sysinfo.TestNetwork.test_interfaces test

### DIFF
--- a/tests/test_agent/test_sysinfo.py
+++ b/tests/test_agent/test_sysinfo.py
@@ -173,10 +173,12 @@ class TestNetwork(TestCase):
 
     def test_interfaces(self):
         names = list(network.interfaces())
-        self.assertEqual(len(names) > 1, True)
+
+        # We assume all hosts have at least the loopback interface.
+        self.assertGreaterEqual(len(names), 1)
         self.assertEqual(isinstance(names, list), True)
-        self.assertEqual(all(name in netifaces.interfaces() for name in names),
-                         True)
+        self.assertTrue(
+            all(name in netifaces.interfaces() for name in names))
 
         addresses = map(netifaces.ifaddresses, names)
         self.assertEqual(all(socket.AF_INET in i for i in addresses), True)


### PR DESCRIPTION
This test assumed there's always more than one interface which
may not always be the case.  For example you've shutoff all network
adapters you should be left with one interface alone.  This of course
assumes all hosts have at least the loopback interface.