### PR TITLE
Reraise KeyError in LoggerPool.log with a better error message

### DIFF
--- a/pyfarm/jobtypes/core/log.py
+++ b/pyfarm/jobtypes/core/log.py
@@ -162,7 +162,11 @@ class LoggerPool(ThreadPool):
             return
 
         # This operation is atomic so we're safe to keep
-        log = self.logs[uuid]
+        try:
+            log = self.logs[uuid]
+        except KeyError:
+            raise KeyError("No such uuid %s, was open_log() called?" % uuid)
+
         log.lines += 1
         log.messages.append((datetime.utcnow(), str(pid) or "", stream,
                              log.lines, message))


### PR DESCRIPTION
KeyError can be raised if you don't call open_log() first.  This
error when running the tests is common for example.  open_log()
is usually called when the job type is started but if you're
writing tests or manually using the log pool the error message
could be more helpful.