### PR TITLE
JobType.tempdir() should handle IOError and WindowsError too

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -484,8 +484,8 @@ class JobType(Cache, System, Process, TypeChecks):
 
         try:
             os.makedirs(parent_dir)
-        except OSError as e:  # pragma: no cover
-            if e.errno != EEXIST:
+        except OSError as error:
+            if error.errno != EEXIST:
                 logger.error("Failed to create %s: %s", parent_dir, e)
                 raise
 

--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -42,6 +42,11 @@ except ImportError:  # pragma: no cover
     from http.client import (
         OK, INTERNAL_SERVER_ERROR, CONFLICT, CREATED, NOT_FOUND, BAD_REQUEST)
 
+try:
+    WindowsError
+except NameError:  # pragma: no cover
+    WindowError = OSError
+
 import treq
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred
@@ -484,7 +489,7 @@ class JobType(Cache, System, Process, TypeChecks):
 
         try:
             os.makedirs(parent_dir)
-        except OSError as error:
+        except (OSError, IOError, WindowError) as error:
             if error.errno != EEXIST:
                 logger.error("Failed to create %s: %s", parent_dir, e)
                 raise


### PR DESCRIPTION
Like most calls to os.makedirs, we should catch IOError and WindowsError too as they can crop up from time to time.