### PR TITLE
Fix JobType.get_environment()

### DIFF
--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -556,23 +556,22 @@ class JobType(Cache, System, Process, TypeChecks):
         # but it's possible to create an environment using the config which
         # contains non-strings.
         for key in environment:
+            value = environment.pop(key)
             if not isinstance(key, STRING_TYPES):
                 logger.warning(
                     "Environment key %r is not a string.  It will be converted "
                     "to a string.", key)
-
-                value = environment.pop(key)
                 key = str(key)
-                environment[key] = value
 
-            if not isinstance(environment[key], STRING_TYPES):
+            if not isinstance(value, STRING_TYPES):
                 logger.warning(
                     "Environment value for %r is not a string.  It will be "
                     "converted to a string.", key)
-                environment[key] = str(environment[key])
+                value = str(value)
+
+            environment[key] = value
 
         return environment
-
     def get_command_list(self, cmdlist):
         """
         Return a list of command to be used when running the process

--- a/pyfarm/jobtypes/core/jobtype.py
+++ b/pyfarm/jobtypes/core/jobtype.py
@@ -528,6 +528,10 @@ class JobType(Cache, System, Process, TypeChecks):
         """
         Constructs an environment dictionary that can be used
         when a process is spawned by a job type.
+
+        :raises TypeError:
+            Raised if ``jobtype_default_environment`` is defined
+            in the config and is not a dictionary.
         """
         environment = {}
         config_environment = config.get("jobtype_default_environment")
@@ -535,7 +539,12 @@ class JobType(Cache, System, Process, TypeChecks):
         if config.get("jobtype_include_os_environ"):
             environment.update(FROZEN_ENVIRONMENT)
 
-        if isinstance(config_environment, dict):
+        if config_environment is not None:
+            if not isinstance(config_environment, dict):
+                raise TypeError(
+                    "Expected the `jobtype_default_environment` configuration "
+                    "value to be a dictionary.")
+
             environment.update(config_environment)
 
         elif config_environment is not None:


### PR DESCRIPTION
This PR updates `get_environment()` a bit so it's more apparent when there's a problem with the configuration.  Before this you could accidentally provide a non-dictionary for `jobtype_default_environment` and you'd never know unless you looked at the agent logs.